### PR TITLE
Restore stdout on windows

### DIFF
--- a/cmd/peco/peco.go
+++ b/cmd/peco/peco.go
@@ -72,6 +72,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	defer peco.TtyTerm()
 
 	err = termbox.Init()
 	if err != nil {


### PR DESCRIPTION
Below doesn't work on windows

```
C:\> ls | peco > file
```
