### PR TITLE
Fix ReadBuffer

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -100,13 +100,10 @@ func (c *Ctx) Buffer() []Match {
 }
 
 func (c *Ctx) ReadBuffer(input io.Reader) error {
-	rdr := bufio.NewReader(input)
-	for {
-		line, err := rdr.ReadString('\n')
+	scanner := bufio.NewScanner(input)
+	for scanner.Scan() {
+		line := scanner.Text()
 		c.lines = append(c.lines, Match{line, nil})
-		if err != nil {
-			break
-		}
 	}
 
 	if len(c.lines) > 0 {


### PR DESCRIPTION
There are problems in original code
- `Match{nil, nil}` is appended if ReadString returns error
- `ReadString` cannot read last line if it does not have newline
