### PR TITLE
Fix dropping input

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -97,7 +97,6 @@ func (f *Filter) Loop() {
 				results = append(results, Match{line.line, ms})
 			}
 
-			f.query = []rune(q)
 			f.DrawMatches(results)
 		}
 	}


### PR DESCRIPTION
この行がなんのためにあるのか、よくわからなかったのですが、大きめのファイルを開いて早めにタイピングしたときに、入力をとりこぼしてしまうことがあるようでした。 

以下のようなことが起こっているみたいです
1. 適当なキー入力 (eg. `foo`)
2. handleAcceptChar からi.ExecQuery("foo")
3. さらにキー入力で  handleAcceptChar (`foob` など)
4. i.ExecQuery("foo") が終わるとこのパッチで削除された場所で query が更新され、3でのキー入力が失われる
