### PR TITLE
Fix synchronization

### DIFF
--- a/cmd/peco/peco.go
+++ b/cmd/peco/peco.go
@@ -143,6 +143,8 @@ func main() {
 	filter := ctx.NewFilter()
 	input := ctx.NewInput()
 
+	// AddWaitGroup must be called in this main thread
+	ctx.AddWaitGroup(3)
 	go view.Loop()
 	go filter.Loop()
 	go input.Loop()

--- a/ctx.go
+++ b/ctx.go
@@ -76,8 +76,8 @@ func (c *Ctx) Result() string {
 	return c.result
 }
 
-func (c *Ctx) AddWaitGroup() {
-	c.wait.Add(1)
+func (c *Ctx) AddWaitGroup(v int) {
+	c.wait.Add(v)
 }
 
 func (c *Ctx) ReleaseWaitGroup() {

--- a/filter.go
+++ b/filter.go
@@ -5,7 +5,6 @@ type Filter struct {
 }
 
 func (f *Filter) Loop() {
-	f.AddWaitGroup()
 	defer f.ReleaseWaitGroup()
 
 	for {

--- a/input.go
+++ b/input.go
@@ -7,7 +7,6 @@ type Input struct {
 }
 
 func (i *Input) Loop() {
-	i.AddWaitGroup()
 	defer i.ReleaseWaitGroup()
 
 	for {

--- a/view.go
+++ b/view.go
@@ -22,7 +22,6 @@ const (
 )
 
 func (u *View) Loop() {
-	u.AddWaitGroup()
 	defer u.ReleaseWaitGroup()
 	for {
 		select {


### PR DESCRIPTION
Because previously everything has been written using non-buffered
channels, the request to refresh the screen would always block.
This resulted in the main thread always waiting to write to
ctx.drawCh until viewer.Loop() registered itself to the waitgroup
via wg.Add(), therefore making the successive wg.Wait() actually wait.

When (this change does not do this) we do use buffered channels,
this guarantee breaks, and the main thread goes immediately to
wg.Wait() before viewer.Loop() has the chance to register
itself to the wait group

This change explicitly forces the main thread to call wg.Add()
to prevent this from happening
