### PR TITLE
Highlight selected line wholly

### DIFF
--- a/view.go
+++ b/view.go
@@ -46,6 +46,11 @@ func printTB(x, y int, fg, bg termbox.Attribute, msg string) {
 		termbox.SetCell(x, y, c, fg, bg)
 		x += runewidth.RuneWidth(c)
 	}
+
+	width, _ := termbox.Size()
+	for ; x < width; x++ {
+		termbox.SetCell(x, y, ' ', fg, bg)
+	}
 }
 
 func (v *View) movePage(p PagingRequest) {


### PR DESCRIPTION
I changed peco to highlight the selected line wholly, because percol behaves so and I like the behavior.
## before

![](http://gifzo.net/id8BiBFc7L.gif)
## after

![](http://gifzo.net/P6sOSnIGEO.gif)
