### PR TITLE
Delete forward char by C-d

### DIFF
--- a/keymap.go
+++ b/keymap.go
@@ -443,6 +443,7 @@ func NewKeymap() Keymap {
 		termbox.KeyCtrlN:      handleSelectNext,
 		termbox.KeyArrowLeft:  handleSelectPreviousPage,
 		termbox.KeyArrowRight: handleSelectNextPage,
+		termbox.KeyCtrlD:      handleDeleteForwardChar,
 		termbox.KeyBackspace:  handleDeleteBackwardChar,
 		termbox.KeyBackspace2: handleDeleteBackwardChar,
 		termbox.KeyCtrlW:      handleDeleteBackwardWord,


### PR DESCRIPTION
Emacs, shell and some readline-like libraries let user delete forward char with Ctrl-D.
I suppose many users expect peco to support the feature by default, thus I added it into keymap.
