### PR TITLE
Add EOF handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Currently only keymaps are supported:
 | peco.BackwardWord       | Move caret backward 1 word|
 | peco.BeginningOfLine    | Move caret to the beginning of line |
 | peco.EndOfLine          | Move caret to the end of line |
+| peco.EndOfFile          | Delete one character forward, otherwise exit from peco with failure status |
 | peco.DeleteForwardChar  | Delete one character forward |
 | peco.DeleteBackwardChar | Delete one character backward |
 | peco.DeleteForwardWord  | Delete one word forward |

--- a/keymap.go
+++ b/keymap.go
@@ -268,6 +268,14 @@ func handleEndOfLine(i *Input, _ termbox.Event) {
 	i.DrawMatches(nil)
 }
 
+func handleEndOfFile(i *Input, ev termbox.Event) {
+	if len(i.query) > 0 {
+		handleDeleteForwardChar(i, ev)
+	} else {
+		handleCancel(i, ev)
+	}
+}
+
 func handleKillBeginOfLine(i *Input, _ termbox.Event) {
 	i.query = i.query[i.caretPos:]
 	i.caretPos = 0
@@ -416,6 +424,7 @@ var handlers = map[string]KeymapHandler{
 	"peco.DeleteAll":          handleDeleteAll,
 	"peco.BeginningOfLine":    handleBeginningOfLine,
 	"peco.EndOfLine":          handleEndOfLine,
+	"peco.EndOfFile":          handleEndOfFile,
 	"peco.ForwardChar":        handleForwardChar,
 	"peco.BackwardChar":       handleBackwardChar,
 	"peco.ForwardWord":        handleForwardWord,


### PR DESCRIPTION
This pull req is related to https://github.com/lestrrat/peco/pull/55 a bit.
Unix shell handles C-d as EOF by default, and it behaves like:
- when shell has some input: delete one character forward
- when shell has no input: exit process

This behavior is useful because you can support both of exiting and forward deletion in one key.
But percol does not support this, so I think this feature should be optional.
