### PR TITLE
Change config default matcher to IgnoreCase

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,7 +13,7 @@ type Config struct {
 func NewConfig() *Config {
 	return &Config{
 		Keymap:  NewKeymap(),
-		Matcher: CaseSensitiveMatch,
+		Matcher: IgnoreCaseMatch,
 	}
 }
 


### PR DESCRIPTION
Default Matcher is set to CaseSensitive when rcfile is given. 

```
echo "a\nb\n" | go run cmd/peco/peco.go
QUERY>                                              IgnoreCase [1/1]
a
b

echo {} > config.json
echo "a\nb\n" | go run cmd/peco/peco.go --rcfile ./config.json
QUERY>                                              CaseSensitive [1/1]
a
b

echo {} > ~/.peco/config.json
echo "a\nb\n" | go run cmd/peco/peco.go
UERY>                                               CaseSensitive [1/1]
a
b
```
