### PR TITLE
Enable style configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ Configuration File
 By default configuration file in ~/.peco/config.json will be searched. You may
 also pass an arbitrary filename via the --rcfile option
 
-Currently only keymaps are supported:
+Currently keymaps and styles are supported.
+
+## Keymaps
 
 ```json
 {
@@ -142,7 +144,7 @@ Currently only keymaps are supported:
 }
 ```
 
-## Available keys:
+### Available keys
 
 | Name        | Notes |
 |-------------|-------|
@@ -167,7 +169,7 @@ Currently only keymaps are supported:
 | ArrowLeft   ||
 | ArrowRight  ||
 
-## Available actions
+### Available actions
 
 | Name | Notes |
 |------|-------|
@@ -191,6 +193,48 @@ Currently only keymaps are supported:
 | peco.RotateMatcher      | Rotate between matchers (by default, ignore-case/no-ignore-case)|
 | peco.Finish             | Exits from peco, with success status |
 | peco.Cancel             | Exits from peco, with failure status |
+
+## Styles
+
+For now, styles of following 3 items can be customized in `config.json`.
+
+```json
+{
+    "Style": {
+        "Basic": ["on_default", "default"],
+        "Selected": ["underline", "on_cyan", "black"],
+        "Query": ["yellow", "bold"]
+    }
+}
+```
+
+### Foreground Colors
+
+- `"black"` for `termbox.ColorBlack`
+- `"red"` for `termbox.ColorRed`
+- `"green"` for `termbox.ColorGreen`
+- `"yellow"` for `termbox.ColorYellow`
+- `"blue"` for `termbox.ColorBlue`
+- `"magenta"` for `termbox.ColorMagenta`
+- `"cyan"` for `termbox.ColorCyan`
+- `"white"` for `termbox.ColorWhite`
+
+### Background Colors
+
+- `"on_black"` for `termbox.ColorBlack`
+- `"on_red"` for `termbox.ColorRed`
+- `"on_green"` for `termbox.ColorGreen`
+- `"on_yellow"` for `termbox.ColorYellow`
+- `"on_blue"` for `termbox.ColorBlue`
+- `"on_magenta"` for `termbox.ColorMagenta`
+- `"on_cyan"` for `termbox.ColorCyan`
+- `"on_white"` for `termbox.ColorWhite`
+
+### Attributes
+
+- `"bold"` for `termbox.AttrBold`
+- `"underline"` for `termbox.AttrUnderline`
+- `"blink"` for `termbox.AttrReverse`
 
 Hacking
 =======

--- a/config.go
+++ b/config.go
@@ -6,14 +6,16 @@ import (
 )
 
 type Config struct {
-	Keymap  Keymap `json:"Keymap"`
-	Matcher string `json:"Matcher"`
+	Keymap  Keymap   `json:"Keymap"`
+	Matcher string   `json:"Matcher"`
+	Style   StyleSet `json:"Style"`
 }
 
 func NewConfig() *Config {
 	return &Config{
 		Keymap:  NewKeymap(),
 		Matcher: IgnoreCaseMatch,
+		Style:   NewStyleSet(),
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,26 @@
+package peco
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestReadRC(t *testing.T) {
+	txt := `
+{
+	"Keymap": {
+		"C-j": "peco.Finish"
+	},
+	"Style": {
+		"Basic": ["on_default", "default"],
+		"Selected": ["underline", "on_cyan", "black"],
+		"Query": ["yellow", "bold"]
+	}
+}
+`
+	cfg := NewConfig()
+	if err := json.Unmarshal([]byte(txt), cfg); err != nil {
+		t.Fatalf("Error unmarshaling json: %s", err)
+	}
+	t.Logf("%#q", cfg)
+}

--- a/keymap_test.go
+++ b/keymap_test.go
@@ -1,26 +1,10 @@
 package peco
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/nsf/termbox-go"
 )
-
-func TestReadRC(t *testing.T) {
-	txt := `
-{
-  "Keymap": {
-   "C-j": "peco.Finish"
-  }
-}
-`
-	cfg := NewConfig()
-	if err := json.Unmarshal([]byte(txt), cfg); err != nil {
-		t.Fatalf("Error unmarshaling json: %s", err)
-	}
-	t.Logf("%#q", cfg)
-}
 
 func TestKeymapStrToKeyValue(t *testing.T) {
 	expected := map[string]termbox.Key{

--- a/style.go
+++ b/style.go
@@ -1,0 +1,93 @@
+package peco
+
+import (
+	"encoding/json"
+
+	"github.com/nsf/termbox-go"
+)
+
+var (
+	stringToFg = map[string]termbox.Attribute{
+		"default": termbox.ColorDefault,
+		"black":   termbox.ColorBlack,
+		"red":     termbox.ColorRed,
+		"green":   termbox.ColorGreen,
+		"yellow":  termbox.ColorYellow,
+		"blue":    termbox.ColorBlue,
+		"magenta": termbox.ColorMagenta,
+		"cyan":    termbox.ColorCyan,
+		"white":   termbox.ColorWhite,
+	}
+	stringToBg = map[string]termbox.Attribute{
+		"on_default": termbox.ColorDefault,
+		"on_black":   termbox.ColorBlack,
+		"on_red":     termbox.ColorRed,
+		"on_green":   termbox.ColorGreen,
+		"on_yellow":  termbox.ColorYellow,
+		"on_blue":    termbox.ColorBlue,
+		"on_magenta": termbox.ColorMagenta,
+		"on_cyan":    termbox.ColorCyan,
+		"on_white":   termbox.ColorWhite,
+	}
+	stringToAttr = map[string]termbox.Attribute{
+		"bold":      termbox.AttrBold,
+		"underline": termbox.AttrUnderline,
+		"blink":     termbox.AttrReverse,
+	}
+)
+
+type StyleSet struct {
+	Basic    Style `json:"Basic"`
+	Selected Style `json:"Selected"`
+	Query    Style `json:"Query"`
+}
+
+func NewStyleSet() StyleSet {
+	return StyleSet{
+		Basic:    Style{fg: termbox.ColorDefault, bg: termbox.ColorDefault},
+		Selected: Style{fg: termbox.ColorDefault, bg: termbox.ColorDefault},
+		Query:    Style{fg: termbox.ColorDefault, bg: termbox.ColorDefault},
+	}
+}
+
+type Style struct {
+	fg termbox.Attribute
+	bg termbox.Attribute
+}
+
+func (s *Style) UnmarshalJSON(buf []byte) error {
+	raw := []string{}
+	if err := json.Unmarshal(buf, &raw); err != nil {
+		return err
+	}
+	*s = *stringsToStyle(raw)
+	return nil
+}
+
+func stringsToStyle(raw []string) *Style {
+	style := &Style{
+		fg: termbox.ColorDefault,
+		bg: termbox.ColorDefault,
+	}
+
+	for _, s := range raw {
+		fg, ok := stringToFg[s]
+		if ok {
+			style.fg = fg
+		}
+
+		bg, ok := stringToBg[s]
+		if ok {
+			style.bg = bg
+		}
+	}
+
+	for _, s := range raw {
+		attr, ok := stringToAttr[s]
+		if ok {
+			style.fg |= attr
+		}
+	}
+
+	return style
+}

--- a/style_test.go
+++ b/style_test.go
@@ -1,0 +1,41 @@
+package peco
+
+import (
+	"testing"
+
+	"github.com/nsf/termbox-go"
+)
+
+type stringsToStyleTest struct {
+	strings []string
+	style   *Style
+}
+
+func TestStringsToStyle(t *testing.T) {
+	tests := []stringsToStyleTest{
+		stringsToStyleTest{
+			strings: []string{"on_default", "default"},
+			style:   &Style{fg: termbox.ColorDefault, bg: termbox.ColorDefault},
+		},
+		stringsToStyleTest{
+			strings: []string{"bold", "on_blue", "yellow"},
+			style:   &Style{fg: termbox.ColorYellow | termbox.AttrBold, bg: termbox.ColorBlue},
+		},
+		stringsToStyleTest{
+			strings: []string{"underline", "on_cyan", "black"},
+			style:   &Style{fg: termbox.ColorBlack | termbox.AttrUnderline, bg: termbox.ColorCyan},
+		},
+		stringsToStyleTest{
+			strings: []string{"blink", "on_red", "white"},
+			style:   &Style{fg: termbox.ColorWhite | termbox.AttrReverse, bg: termbox.ColorRed},
+		},
+	}
+
+	t.Logf("Checking strings -> color mapping...")
+	for _, test := range tests {
+		t.Logf("    checking %s...", test.strings)
+		if a := stringsToStyle(test.strings); *a != *test.style {
+			t.Errorf("Expected '%s' to be '%#v', but got '%#v'", test.strings, test.style, a)
+		}
+	}
+}

--- a/view.go
+++ b/view.go
@@ -152,11 +152,11 @@ CALCULATE_PAGE:
 	printTB(width-runewidth.StringWidth(pmsg), 0, termbox.ColorDefault, termbox.ColorDefault, pmsg)
 
 	for n := 1; n <= perPage; n++ {
-		fgAttr := termbox.ColorDefault
-		bgAttr := termbox.ColorDefault
+		fgAttr := u.config.Style.Basic.fg
+		bgAttr := u.config.Style.Basic.bg
 		if n == u.selectedLine-offset {
-			fgAttr = termbox.AttrUnderline
-			bgAttr = termbox.ColorMagenta
+			fgAttr = u.config.Style.Selected.fg
+			bgAttr = u.config.Style.Selected.bg
 		}
 
 		targetIdx := offset + n - 1
@@ -178,14 +178,14 @@ CALCULATE_PAGE:
 					index += len(c)
 				}
 				c := line[m[0]:m[1]]
-				printTB(prev, n, fgAttr|termbox.ColorCyan, bgAttr, c)
+				printTB(prev, n, u.config.Style.Query.fg, bgAttr|u.config.Style.Query.bg, c)
 				prev += runewidth.StringWidth(c)
 				index += len(c)
 			}
 
 			m := target.matches[len(target.matches)-1]
 			if m[0] > prev {
-				printTB(prev, n, fgAttr|termbox.ColorCyan, bgAttr, line[m[0]:m[1]])
+				printTB(prev, n, u.config.Style.Query.fg, bgAttr|u.config.Style.Query.bg, line[m[0]:m[1]])
 			} else if len(line) > m[1] {
 				printTB(prev, n, fgAttr, bgAttr, line[m[1]:len(line)])
 			}


### PR DESCRIPTION
I supported custom style feature of percol.
## Original

Originally, you can write custom style like:

``` python
percol.view.CANDIDATES_LINE_BASIC    = ("on_default", "default")
percol.view.CANDIDATES_LINE_SELECTED = ("underline", "on_yellow", "white")
percol.view.CANDIDATES_LINE_MARKED   = ("bold", "on_cyan", "black")
percol.view.CANDIDATES_LINE_QUERY    = ("yellow", "bold")
```
## Peco version

In this pull req, I supported them except "marked".
After merging this pull req, you'll be able to configure like:

``` json
{
    "Style": {
        "Basic": ["on_default", "default"],
        "Selected": ["underline", "on_cyan", "black"],
        "Query": ["yellow", "bold"]
    }
}
```
## Demo

By this config.json, you'll see:
![](https://gist.githubusercontent.com/k0kubun/d211d8ee67df64610e0c/raw/zsh.png)
