### PR TITLE
Fix default style

### DIFF
--- a/style.go
+++ b/style.go
@@ -45,8 +45,8 @@ type StyleSet struct {
 func NewStyleSet() StyleSet {
 	return StyleSet{
 		Basic:    Style{fg: termbox.ColorDefault, bg: termbox.ColorDefault},
-		Selected: Style{fg: termbox.ColorDefault, bg: termbox.ColorDefault},
-		Query:    Style{fg: termbox.ColorDefault, bg: termbox.ColorDefault},
+		Selected: Style{fg: termbox.ColorDefault | termbox.AttrUnderline, bg: termbox.ColorMagenta},
+		Query:    Style{fg: termbox.ColorCyan, bg: termbox.ColorDefault},
 	}
 }
 


### PR DESCRIPTION
After merging https://github.com/lestrrat/peco/pull/59, I noticed that I broke original default behavior.
Because I've set all style `termbox.ColorDefault`, selected line and query word are not highlighted.
This is not intended, so I fixed that. Sorry.
## before (unintended)

![](https://gist.github.com/k0kubun/d211d8ee67df64610e0c/raw/8bb69bf2f76f0a8502e08df3545a60e806eed568/before.png)
## after (original behavior)

![](https://gist.github.com/k0kubun/d211d8ee67df64610e0c/raw/16544e55a12e3597bdd3074447d4af46123531fd/after2.png)
