### PR TITLE
Skip unnecessary queries for continuous inputs

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -151,6 +151,15 @@ func (c *Ctx) Terminate() {
 }
 
 func (c *Ctx) ExecQuery(v string) {
+	// Clear existing queries
+	CLEAR: for {
+		select {
+			case <-c.queryCh:
+				// discard
+			default:
+				break CLEAR
+		}
+	}
 	c.queryCh <- v
 }
 


### PR DESCRIPTION
大きめのファイルで連続して入力した際、途中の検索で詰まってなかなか最後まで終わらないので、新規入力があった場合、キューに溜まっているクエリは破棄するようにしました。
