### PR TITLE
Fix binding 'C-Space' issue

### DIFF
--- a/input.go
+++ b/input.go
@@ -43,7 +43,7 @@ func (i *Input) Loop() {
 }
 
 func (i *Input) handleKeyEvent(ev termbox.Event) {
-	if h := i.config.Keymap.Handler(ev.Key); h != nil {
+	if h := i.config.Keymap.Handler(ev); h != nil {
 		h(i, ev)
 		return
 	}

--- a/keymap.go
+++ b/keymap.go
@@ -478,10 +478,12 @@ func NewKeymap() Keymap {
 	}
 }
 
-func (km Keymap) Handler(k termbox.Key) KeymapHandler {
-	h, ok := km[k]
-	if ok {
-		return h
+func (km Keymap) Handler(ev termbox.Event) KeymapHandler {
+	if ev.Ch == 0 {
+		h, ok := km[ev.Key]
+		if ok {
+			return h
+		}
 	}
 	return handleAcceptChar
 }


### PR DESCRIPTION
We should check both 'ev.Key' and 'ev.Ch'. Because ev.Key is always '0'
if input does not have prefix('Ctrl-', 'Alt-') or input is not some
special key. If user binds some command to 'C-Space' or 'C-2', 'C-~'
(then that command is set to 'input.config.Keymap[0]'), the command
is executed by inputting non-prefix key like 'a', 'b', 'c'.
