### PR TITLE
fix crush on empty current Match

### DIFF
--- a/keymap.go
+++ b/keymap.go
@@ -131,7 +131,9 @@ func handleFinish(i *Input, _ termbox.Event) {
 
 	i.result = []string{}
 	for _, lineno := range i.selection {
-		i.result = append(i.result, i.current[lineno-1].Line())
+		if lineno <= len(i.current) {
+			i.result = append(i.result, i.current[lineno-1].Line())
+		}
 	}
 	i.Finish()
 }


### PR DESCRIPTION
`handleFinish` crashes when there is no matches on current query.
it should check before access `i.current[lineno-1]`.
