### PR TITLE
Add ToggleSelectionAndSelectNext handler which executes.

### DIFF
--- a/keymap.go
+++ b/keymap.go
@@ -144,6 +144,11 @@ func handleToggleSelection(i *Input, _ termbox.Event) {
 	i.selection.Add(i.currentLine)
 }
 
+func handleToggleSelectionAndSelectNext(i *Input, ev termbox.Event) {
+	handleToggleSelection(i, ev)
+	handleSelectNext(i, ev)
+}
+
 // peco.Cancel -> end program, exit with failure
 func handleCancel(i *Input, ev termbox.Event) {
 	i.ExitStatus = 1
@@ -430,27 +435,28 @@ func (ksk KeymapStringKey) ToKey() (k termbox.Key, err error) {
 }
 
 var handlers = map[string]KeymapHandler{
-	"peco.KillEndOfLine":      handleKillEndOfLine,
-	"peco.DeleteAll":          handleDeleteAll,
-	"peco.BeginningOfLine":    handleBeginningOfLine,
-	"peco.EndOfLine":          handleEndOfLine,
-	"peco.EndOfFile":          handleEndOfFile,
-	"peco.ForwardChar":        handleForwardChar,
-	"peco.BackwardChar":       handleBackwardChar,
-	"peco.ForwardWord":        handleForwardWord,
-	"peco.BackwardWord":       handleBackwardWord,
-	"peco.DeleteForwardChar":  handleDeleteForwardChar,
-	"peco.DeleteBackwardChar": handleDeleteBackwardChar,
-	"peco.DeleteForwardWord":  handleDeleteForwardWord,
-	"peco.DeleteBackwardWord": handleDeleteBackwardWord,
-	"peco.SelectPreviousPage": handleSelectPreviousPage,
-	"peco.SelectNextPage":     handleSelectNextPage,
-	"peco.SelectPrevious":     handleSelectPrevious,
-	"peco.SelectNext":         handleSelectNext,
-	"peco.ToggleSelection":    handleToggleSelection,
-	"peco.RotateMatcher":      handleRotateMatcher,
-	"peco.Finish":             handleFinish,
-	"peco.Cancel":             handleCancel,
+	"peco.KillEndOfLine":                handleKillEndOfLine,
+	"peco.DeleteAll":                    handleDeleteAll,
+	"peco.BeginningOfLine":              handleBeginningOfLine,
+	"peco.EndOfLine":                    handleEndOfLine,
+	"peco.EndOfFile":                    handleEndOfFile,
+	"peco.ForwardChar":                  handleForwardChar,
+	"peco.BackwardChar":                 handleBackwardChar,
+	"peco.ForwardWord":                  handleForwardWord,
+	"peco.BackwardWord":                 handleBackwardWord,
+	"peco.DeleteForwardChar":            handleDeleteForwardChar,
+	"peco.DeleteBackwardChar":           handleDeleteBackwardChar,
+	"peco.DeleteForwardWord":            handleDeleteForwardWord,
+	"peco.DeleteBackwardWord":           handleDeleteBackwardWord,
+	"peco.SelectPreviousPage":           handleSelectPreviousPage,
+	"peco.SelectNextPage":               handleSelectNextPage,
+	"peco.SelectPrevious":               handleSelectPrevious,
+	"peco.SelectNext":                   handleSelectNext,
+	"peco.ToggleSelection":              handleToggleSelection,
+	"peco.ToggleSelectionAndSelectNext": handleToggleSelectionAndSelectNext,
+	"peco.RotateMatcher":                handleRotateMatcher,
+	"peco.Finish":                       handleFinish,
+	"peco.Cancel":                       handleCancel,
 }
 
 func NewKeymap() Keymap {


### PR DESCRIPTION
I added ToggleSelectionAndSelectNext which select next line after ToggleSelection.

Percol's C-SPACE is bound to `percol.command.toggle_mark_and_next` like `ToggleSelectionAndSelectNext` by default.
If you don't mind, I think it is better to bind C-SPACE to ToggleSelectionAndSelectNext in peco too.

https://github.com/mooz/percol#selecting-multiple-candidates
