### PR TITLE
fix package path

### DIFF
--- a/cmd/peco/peco.go
+++ b/cmd/peco/peco.go
@@ -7,7 +7,7 @@ import (
 	"syscall"
 
 	"github.com/jessevdk/go-flags"
-	"github.com/lestrrat/peco"
+	"github.com/peco/peco"
 	"github.com/nsf/termbox-go"
 )
 


### PR DESCRIPTION
Since I failed to build, I was fixed path.

```
$ go get github.com/peco/peco
$ cd ${GOPATH}/src/peco/peco
$ go build cmd/peco/peco.go
cmd/peco/peco.go:10:2: cannot find package "github.com/lestrrat/peco" in any of:
        /usr/local/Cellar/go/1.2.2/libexec/src/pkg/github.com/lestrrat/peco (from $GOROOT)
        /Users/takkanm/go/src/github.com/lestrrat/peco (from $GOPATH)
```
