### PR TITLE
Add SetInputMode() for windows. Windows can handle Esc/Alt both

### DIFF
--- a/cmd/peco/peco.go
+++ b/cmd/peco/peco.go
@@ -146,6 +146,11 @@ func main() {
 	}
 	defer termbox.Close()
 
+	// Windows handle Esc/Alt self
+	if runtime.GOOS == "windows" {
+		termbox.SetInputMode(termbox.InputEsc | termbox.InputAlt)
+	}
+
 	view := ctx.NewView()
 	filter := ctx.NewFilter()
 	input := ctx.NewInput()


### PR DESCRIPTION
Note that you need latest termbox-go
