### PR TITLE
Issue 98

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -265,7 +265,7 @@ MATCH:
 			// so we punt it by letting the close() happen at a separate
 			// goroutine, protected by a defer recover()
 			go func() {
-				defer recover()
+				defer func() { recover() }()
 				close(iter)
 			}()
 			break MATCH


### PR DESCRIPTION
fixes #98 by ignoring panics induced by "close of a closed channel"
this is okay in this scenario, because all we're doing is to "cancel" a query, and we really don't care as long as it's, um, canceled.
