### PR TITLE
Use C-c for handleCancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Note: If in case below keymap seems wrong, check the source code in [keymap.go](
 
 |Key|Action|
 |---|------|
-|Ctrl-c|handleCancel|
+|Esc|handleCancel|
 |Enter|handleFinish|
 |Ctrl-n|handleSelectNext|
 |Ctrl-p|handleSelectPrevious|

--- a/keymap.go
+++ b/keymap.go
@@ -491,6 +491,7 @@ var handlers = map[string]KeymapHandler{
 func NewKeymap() Keymap {
 	return Keymap{
 		{
+			termbox.KeyEsc:        handleCancel,
 			termbox.KeyCtrlC:      handleCancel,
 			termbox.KeyEnter:      handleFinish,
 			termbox.KeyArrowUp:    handleSelectPrevious,


### PR DESCRIPTION
handleCancel is called by Esc in peco, but C-c in percol.
I think this is a bit harmful for transition users from percol. So I changed the default keymap.
