### PR TITLE
Support --initial-index option like percol

### DIFF
--- a/cmd/peco/peco.go
+++ b/cmd/peco/peco.go
@@ -24,6 +24,7 @@ Options:
   --no-ignore-case      start in case-sensitive mode
   -b, --buffer-size     number of lines to keep in search buffer
   --null                expect NUL (\0) as separator for target/output (EXPERIMENTAL)
+  --initial-index       position of the initial index of the selection
 `
 	os.Stderr.Write([]byte(v))
 }
@@ -37,6 +38,7 @@ type cmdOptions struct {
 	OptVersion       bool   `long:"version" description:"print the version and exit"`
 	OptBufferSize    int    `long:"buffer-size" short:"b" description:"number of lines to keep in search buffer"`
 	OptEnableNullSep bool   `long:"null" description:"expect NUL (\\0) as separator for target/output"`
+	OptInitialIndex  int    `long:"initial-index" description:"position of the initial index of the selection"`
 }
 
 // BufferSize returns the specified buffer size. Fulfills peco.CtxOptions
@@ -47,6 +49,14 @@ func (o cmdOptions) BufferSize() int {
 // EnableNullSep returns tru if --null was specified. Fulfills peco.CtxOptions
 func (o cmdOptions) EnableNullSep() bool {
 	return o.OptEnableNullSep
+}
+
+func (o cmdOptions) InitialIndex() int {
+	if o.OptInitialIndex > 0 {
+		return o.OptInitialIndex
+	} else {
+		return 1
+	}
 }
 
 func main() {

--- a/ctx.go
+++ b/ctx.go
@@ -13,6 +13,7 @@ import (
 type CtxOptions interface {
 	EnableNullSep() bool
 	BufferSize() int
+	InitialIndex() int
 }
 
 type Selection []int
@@ -100,7 +101,7 @@ func NewCtx(o CtxOptions) *Ctx {
 		sync.Mutex{},
 		[]rune{},
 		0,
-		1,
+		o.InitialIndex(),
 		Selection([]int{}),
 		[]Match{},
 		nil,

--- a/view.go
+++ b/view.go
@@ -127,6 +127,9 @@ func (v *View) drawScreen(targets []Match) {
 			targets = v.Ctx.lines
 		}
 	}
+	if v.Ctx.currentLine > len(targets) && len(targets) > 0 {
+		v.Ctx.currentLine = len(targets)
+	}
 
 	width, height := termbox.Size()
 	perPage := height - 4


### PR DESCRIPTION
```
$ echo -e "one\ntwo\nsan" | ./peco
QUERY>
one <- SELECTED
two
san

$ echo -e "one\ntwo\nsan" | ./peco --initial-index 2
QUERY>
one
two <- SELECTED
san
```
