### PR TITLE
Fix handling initial index larger than liens per page

### DIFF
--- a/view.go
+++ b/view.go
@@ -150,6 +150,10 @@ CALCULATE_PAGE:
 	}
 
 	if maxPage < currentPage.index {
+		if len(targets) == 0 && len(v.Ctx.query) == 0 {
+			// wait for targets
+			return
+		}
 		v.Ctx.currentLine = currentPage.offset
 		goto CALCULATE_PAGE
 	}


### PR DESCRIPTION
#123 の 2 番目の指摘の、--initial-indexの値が perPage を超えてた場合の件です。

targetsが空の場合に、起動直後でまたセットされてないのか、検索にマッチしなくて空なのかを区別できればいいと思うのですが、これで動いたのでPRしてみます。

が、かなりアドホックな感じがするので、ほかによい方法があったら教えてくもらえるとうれしいです＞＜

(LoopでDrawChのlines(のちのtargets)が来てから初回のdrawScreenが呼ばれるようにできればいいと思うのですが…)
