### PR TITLE
Fix query line highlight

### DIFF
--- a/view.go
+++ b/view.go
@@ -186,8 +186,8 @@ CALCULATE_PAGE:
 		// the caret is in the middle of the string
 		prev := 0
 		for i, r := range v.query {
-			fg := termbox.ColorDefault
-			bg := termbox.ColorDefault
+			fg := v.config.Style.Query.fg
+			bg := v.config.Style.Query.bg
 			if i == v.caretPos {
 				fg |= termbox.AttrReverse
 				bg |= termbox.AttrReverse


### PR DESCRIPTION
I fixed a tiny bug in https://github.com/peco/peco/pull/131.
Currently peco highlights the query word only when caretPos is in the end of query word.
## before

![](https://camo.githubusercontent.com/f7b7cf62d06501313a473d7844e02aa6324796a8/687474703a2f2f6769667a6f2e6e65742f61313557393056344b332e676966)
## after

![](http://gifzo.net/BTLxAfRkYTI.gif)
