### PR TITLE
Fulfill terminal height

### DIFF
--- a/view.go
+++ b/view.go
@@ -25,6 +25,7 @@ const (
 	ToPrevLine
 	// ToPrevPage moves the selection to the previous page
 	ToPrevPage
+	QueryHeight = 1
 )
 
 // Loop receives requests to update the screen
@@ -87,7 +88,7 @@ func printTB(x, y int, fg, bg termbox.Attribute, msg string) {
 
 func (v *View) movePage(p PagingRequest) {
 	_, height := termbox.Size()
-	perPage := height - 4
+	perPage := height - QueryHeight
 
 	switch p {
 	case ToPrevLine:
@@ -138,7 +139,7 @@ func (v *View) drawScreen(targets []Match) {
 	}
 
 	width, height := termbox.Size()
-	perPage := height - 4
+	perPage := height - QueryHeight
 
 CALCULATE_PAGE:
 	currentPage := &v.Ctx.currentPage


### PR DESCRIPTION
When list is paginated, there is 3-lines empty at the bottom.
So I fixed it to be fulfilled.
(By the way, percol is also fulfilled)

![Comparison screenshot](http://gyazo-yuyat.heroku.com/81091094801167a45541929acd3ec210.png)
(Left: current peco, Center: peco patched by me, Right: percol)

Is there any reason for this empty lines?
