### PR TITLE
promptを下にしたかった

### DIFF
--- a/cmd/peco/peco.go
+++ b/cmd/peco/peco.go
@@ -26,6 +26,7 @@ Options:
   --null                expect NUL (\0) as separator for target/output (EXPERIMENTAL)
   --initial-index       position of the initial index of the selection (0 base)
   --prompt              specify prompt
+  --reverse             reverse mode
 `
 	os.Stderr.Write([]byte(v))
 }
@@ -34,13 +35,14 @@ type cmdOptions struct {
 	OptHelp          bool   `short:"h" long:"help" description:"show this help message and exit"`
 	OptTTY           string `long:"tty" description:"path to the TTY (usually, the value of $TTY)"`
 	OptQuery         string `long:"query"`
-	OptRcfile        string `long:"rcfile" descriotion:"path to the settings file"`
+	OptRcfile        string `long:"rcfile" description:"path to the settings file"`
 	OptNoIgnoreCase  bool   `long:"no-ignore-case" description:"start in case-sensitive-mode" default:"false"`
 	OptVersion       bool   `long:"version" description:"print the version and exit"`
 	OptBufferSize    int    `long:"buffer-size" short:"b" description:"number of lines to keep in search buffer"`
 	OptEnableNullSep bool   `long:"null" description:"expect NUL (\\0) as separator for target/output"`
 	OptInitialIndex  int    `long:"initial-index" description:"position of the initial index of the selection (0 base)"`
 	OptPrompt        string `long:"prompt"`
+	OptReverse       bool   `long:"reverse"`
 }
 
 // BufferSize returns the specified buffer size. Fulfills peco.CtxOptions
@@ -51,6 +53,10 @@ func (o cmdOptions) BufferSize() int {
 // EnableNullSep returns tru if --null was specified. Fulfills peco.CtxOptions
 func (o cmdOptions) EnableNullSep() bool {
 	return o.OptEnableNullSep
+}
+
+func (o cmdOptions) Reverse() bool {
+	return o.OptReverse
 }
 
 func (o cmdOptions) InitialIndex() int {

--- a/ctx.go
+++ b/ctx.go
@@ -14,6 +14,7 @@ type CtxOptions interface {
 	EnableNullSep() bool
 	BufferSize() int
 	InitialIndex() int
+	Reverse() bool
 }
 
 type Selection []int
@@ -88,6 +89,7 @@ type Ctx struct {
 	CurrentMatcher      int
 	ExitStatus          int
 	selectionRangeStart int
+	reverse             bool
 
 	wait *sync.WaitGroup
 }
@@ -120,6 +122,7 @@ func NewCtx(o CtxOptions) *Ctx {
 		0,
 		0,
 		NoSelectionRange,
+		o.Reverse(),
 		&sync.WaitGroup{},
 	}
 }


### PR DESCRIPTION
terminalを操作していると、promptはだいたい画面下に表示されるようになる。
pecoを使うとき、視線が↓↑↓と移動して大変だったので、pecoのpromptを下に表示したかった。

ひとまずpecoのscreenを上下逆にしてみた。
goのtutorialすら読まずに書き換えたので、きちんとqoを勉強して綺麗に書き直したい。
