### PR TITLE
Delay the terminal initialization until incoming buffer is ready

### DIFF
--- a/cmd/peco/peco.go
+++ b/cmd/peco/peco.go
@@ -150,6 +150,15 @@ func main() {
 		ctx.SetCurrentMatcher(peco.CaseSensitiveMatch)
 	}
 
+	// Try waiting for something available in the source stream
+	// before doing any terminal initialization (also done by termbox)
+	reader := ctx.NewBufferReader(in)
+	ctx.AddWaitGroup(1)
+	go reader.Loop()
+
+	// This channel blocks until we receive something from `in`
+	<-reader.InputReadyCh()
+
 	err = peco.TtyReady()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -174,13 +183,11 @@ func main() {
 	view := ctx.NewView()
 	filter := ctx.NewFilter()
 	input := ctx.NewInput()
-	reader := ctx.NewBufferReader(in)
 	sig := ctx.NewSignalHandler()
 
 	loopers := []interface {
 		Loop()
 	}{
-		reader,
 		view,
 		filter,
 		input,

--- a/ctx.go
+++ b/ctx.go
@@ -232,7 +232,7 @@ func (c *Ctx) Buffer() []Match {
 }
 
 func (c *Ctx) NewBufferReader(r io.ReadCloser) *BufferReader {
-	return &BufferReader{c, r}
+	return &BufferReader{c, r, make(chan struct{})}
 }
 
 func (c *Ctx) NewView() *View {


### PR DESCRIPTION
This change fixes #144 by delaying all the terminal initialization
until there's something coming in from the standard input.

Without this, for example, a succesive chain of commands that expect to
use stdin will fail, because peco might accidentally grab the stdin
under the hood. With this change, peco is forced to wait to do any
terminal related stuff until some output has been spewed by the
previous command (which is most likely when the command is ready to
give up the control of the terminal), so things work again.
