### PR TITLE
Change how peco.Finish handles the line under cursor

### DIFF
--- a/action.go
+++ b/action.go
@@ -210,7 +210,9 @@ func doSelectVisible(i *Input, _ termbox.Event) {
 
 func doFinish(i *Input, _ termbox.Event) {
 	// Must end with all the selected lines.
-	i.selection.Add(i.currentLine)
+	if i.selection.Len() == 0 {
+		i.selection.Add(i.currentLine)
+	}
 
 	i.result = []Match{}
 	for _, lineno := range append(i.selection, i.RangeSelection()...) {


### PR DESCRIPTION
Only add the line where the cursor is if there are no other
selected lines before hand. This apparently matches what percol does,
and I agree that it's more intuitive

refs: http://twitter.com/mattn_jp/status/485951916040413184
