### PR TITLE
Add finish command with exit status code 101 and 102.

### DIFF
--- a/action.go
+++ b/action.go
@@ -69,6 +69,8 @@ func init() {
 	ActionFunc(doEndOfFile).Register("EndOfFile")
 	ActionFunc(doEndOfLine).Register("EndOfLine", termbox.KeyCtrlE)
 	ActionFunc(doFinish).Register("Finish", termbox.KeyEnter)
+	ActionFunc(doFinishWith101).Register("FinishWith101")
+	ActionFunc(doFinishWith102).Register("FinishWith102")
 	ActionFunc(doForwardChar).Register("ForwardChar", termbox.KeyCtrlF)
 	ActionFunc(doForwardWord).Register("ForwardWord")
 	ActionFunc(doKillEndOfLine).Register("KillEndOfLine", termbox.KeyCtrlK)
@@ -229,6 +231,36 @@ func doFinish(i *Input, _ termbox.Event) {
 		}
 	}
 	i.ExitWith(0)
+}
+
+func doFinishWith101(i *Input, _ termbox.Event) {
+	// Must end with all the selected lines.
+	if i.selection.Len() == 0 {
+		i.selection.Add(i.currentLine)
+	}
+
+	i.result = []Match{}
+	for _, lineno := range i.selection {
+		if lineno <= len(i.current) {
+			i.result = append(i.result, i.current[lineno-1])
+		}
+	}
+	i.ExitWith(101)
+}
+
+func doFinishWith102(i *Input, _ termbox.Event) {
+	// Must end with all the selected lines.
+	if i.selection.Len() == 0 {
+		i.selection.Add(i.currentLine)
+	}
+
+	i.result = []Match{}
+	for _, lineno := range i.selection {
+		if lineno <= len(i.current) {
+			i.result = append(i.result, i.current[lineno-1])
+		}
+	}
+	i.ExitWith(102)
 }
 
 func doCancel(i *Input, ev termbox.Event) {


### PR DESCRIPTION
Zawやemacsのhelm, anythingやvimのuniteのように、候補を絞った後、選択する際のキーによってactionを変えたい時のために、終了statusを0以外にするfinish commandを作成しました。
# コマンドの使用例

以下のようなzshの関数を作ります。

``` sh
function peco-select-history() {
    local tac
    BUFFER=$(history -n -r 1 | \
        peco --query "$LBUFFER")
    if [[ "$?" == "0" ]]; then
        zle accept-line
    else
        CURSOR=$#BUFFER
    fi
    zle clear-screen
}
```

また、以下のような設定をしておきます。

``` json
{
    "Keymap": {
        "C-j": "peco.FinishWith101"}
}
```

この状態で`peco-select-history`を実行し、絞り込みを選択する際に`Ret`で選択すると、履歴をそのまま実行。
`C-j`で選択すると、現在のshellに表示して、編集可能な状態で終了します。
