### PR TITLE
Action to kill processes from ps output

### DIFF
--- a/proc_manager.go
+++ b/proc_manager.go
@@ -1,0 +1,49 @@
+package peco
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+/*
+	Find the index of the column that contains PID, if it exists.
+	If not, this is probably not a ps output.
+*/
+func findPIDIndex(line string) (int, bool) {
+
+	for idx, chunk := range splitAndTrim(line) {
+		if chunk == "PID" {
+			return idx, true
+		}
+	}
+	return 0, false
+}
+
+/*
+	If the pid in the given column is valid, try to kill it
+*/
+func killPID(line string, idx int) bool {
+	cols := splitAndTrim(line)
+	pid, err := strconv.Atoi(cols[idx])
+
+	if err != nil {
+		return false
+	}
+
+	if proc, err := os.FindProcess(pid); err == nil {
+		err = proc.Kill()
+		return err == nil
+	}
+	return false
+}
+
+func splitAndTrim(in string) []string {
+	out := []string{}
+	for _, col := range strings.Split(in, " ") {
+		if col != "" {
+			out = append(out, col)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
This only works if the given input is output from ps. Using `ctrl+\` you can kill whatever process is currently selected. Also works with multiple selections.

![example](https://cloud.githubusercontent.com/assets/1839953/3565992/fd8efa90-0ade-11e4-82f0-afba88f42b93.gif)
