### PR TITLE
Fix bug with ansi escape sequence

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"io"
 	"os"
-    "regexp"
+	"regexp"
 	"sync"
 	"time"
 )
 
-var ansiEscape = regexp.MustCompile("\x1B\\[(?:[0-9]{1,2}(?:;[0-9]{1,2})?)?[m|K]");
+// Global var used to strips ansi sequences
+var ansiStrips = regexp.MustCompile("\x1B\\[(?:[0-9]{1,2}(?:;[0-9]{1,2})?)?[m|K]")
 
 // BufferReader reads lines from the input, either Stdin or a file.
 // If the incoming data is endless, it keeps reading and adding to
@@ -65,7 +66,7 @@ func (b *BufferReader) Loop() {
 			}
 
 			if line != "" {
-                line = EscapeAnsiChar(line)
+				line = StripsAnsiSequences(line)
 				once.Do(func() { b.inputReadyCh <- struct{}{} })
 				m.Lock()
 				b.lines = append(b.lines, NewNoMatch(line, b.enableSep))
@@ -100,6 +101,7 @@ func (b *BufferReader) Loop() {
 	}
 }
 
-func EscapeAnsiChar(s string) string {
-    return ansiEscape.ReplaceAllString(s, "")
+// Function who strips ansi sequences
+func StripsAnsiSequences(s string) string {
+	return ansiStrips.ReplaceAllString(s, "")
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -2,20 +2,21 @@ package peco
 
 import "testing"
 
-func TestAsciiEscape(t *testing.T) {
-	test := EscapeAnsiChar("this is not a pipe")
+// some little test to validate ansi strips function
+func TestAnsiStrips(t *testing.T) {
+	test := StripsAnsiSequences("this is not a pipe")
 	if test != "this is not a pipe" {
 		t.Errorf("expected String = 'this is not a pipe', got '%s'", test)
 	}
-	test = EscapeAnsiChar(" [01;34helloWorld [0m")
+	test = StripsAnsiSequences(" [01;34helloWorld [0m")
 	if test != " [01;34helloWorld [0m" {
 		t.Errorf("expected String = ' [01;34mhelloWorld [0m', got '%s'", test)
 	}
-	test = EscapeAnsiChar("\x1b[01;34mthe answer to life is \x1b[0;42m42")
+	test = StripsAnsiSequences("\x1b[01;34mthe answer to life is \x1b[0;42m42")
 	if test != "the answer to life is 42" {
 		t.Errorf("expected String = 'the answer to life is 42' , got '%s'", test)
 	}
-	test = EscapeAnsiChar("x1b[01;34mthe answer to life is x1b[0;42m42")
+	test = StripsAnsiSequences("x1b[01;34mthe answer to life is x1b[0;42m42")
 	if test != "x1b[01;34mthe answer to life is x1b[0;42m42" {
 		t.Errorf("expected String = 'x1b[01;34mthe answer to life is x1b[0;42m42' , got '%s'", test)
 	}


### PR DESCRIPTION
Fix bug with ansi escape sequence

EX:
when you type:
ls --color | peco

your output look like

 [0m [01;36mbin [0m  
 [01;34mboot [0m
 [01;34mdev [0m
 [01;34metc [0m

now output are correctly displayed

bin  
boot
dev
