### PR TITLE
Initial matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Changes how peco interprets incoming data. When this flag is set, you may insert
 
 [Here's a simple example of how to use this feature](https://gist.github.com/mattn/3c7a14c1677ecb193acd)
 
-### --no-ignore-case
+### --no-ignore-case *Deprecated*
 
 By default peco starts in case insensitive mode. When this option is specified, peco will start in case sensitive mode. This can be toggled while peco is still in session.
 

--- a/cmd/peco/peco.go
+++ b/cmd/peco/peco.go
@@ -147,6 +147,7 @@ func main() {
 		}
 	}
 
+	// Deprecated. --no-ignore-case options will be removed in later.
 	if opts.OptNoIgnoreCase {
 		ctx.SetCurrentMatcher(peco.CaseSensitiveMatch)
 	}


### PR DESCRIPTION
https://twitter.com/RENDAAAAAA/statuses/496128250263764993

Japanese

> pecoに起動時のMatcherを指定出来るオプションないかなあ。C-r何回か押してmigemoに切り替えてから検索文字列入力、だとやや面倒。 

English

> I wonder if there is no option to specify the Matcher during start-up peco. Press several times C-r to the search after switching to migemo, It is somewhat cumbersome.
