### PR TITLE
Improve verification for custom matcher

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -201,7 +201,7 @@ func NewCustomMatcher(enableSep bool, name string, args []string) *CustomMatcher
 // is actual found and is executable via exec.LookPath
 func (m *CustomMatcher) Verify() error {
 	if len(m.args) == 0 {
-		return fmt.Errorf("'%s' doesn't specify executable", m.name)
+		return fmt.Errorf("no executable specified for custom matcher '%s'", m.name)
 	}
 
 	if _, err := exec.LookPath(m.args[0]); err != nil {


### PR DESCRIPTION
This change also avoids run time error(index out of range).

Users may write following configuration by mistake.
Then run time error is not preferable for them.

``` json
{
    "CustomMatcher": {
        "SomeCustomMatcher": [
        ]
    }
}
```
