### PR TITLE
Simple change to avoid using an array

### DIFF
--- a/action.go
+++ b/action.go
@@ -224,12 +224,17 @@ func doFinish(i *Input, _ termbox.Event) {
 		i.SelectionAdd(i.currentLine)
 	}
 
-	i.result = []Match{}
-	for _, lineno := range append(i.selection.GetSelection(), i.SelectedRange().GetSelection()...) {
-		if lineno <= i.GetCurrentLen() {
-			i.result = append(i.result, i.GetCurrentAt(lineno-1))
+	i.resultCh = make(chan Match)
+	lines := append(i.selection.GetSelection(), i.SelectedRange().GetSelection()...)
+	go func(ch chan Match, lines []int) {
+		for _, lineno := range lines {
+			if lineno <= i.GetCurrentLen() {
+				ch <- i.GetCurrentAt(lineno-1)
+			}
 		}
-	}
+		close(ch)
+	}(i.resultCh, lines)
+
 	i.ExitWith(0)
 }
 

--- a/cmd/peco/peco.go
+++ b/cmd/peco/peco.go
@@ -142,14 +142,17 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Error:\n%s", err)
 		}
 
-		if result := ctx.Result(); result != nil {
-			for _, match := range result {
-				line := match.Output()
-				if line[len(line)-1] != '\n' {
-					line = line + "\n"
-				}
-				fmt.Fprint(os.Stdout, line)
+		ch := ctx.ResultCh()
+		if ch == nil {
+			return
+		}
+
+		for match := range ch {
+			line := match.Output()
+			if line[len(line)-1] != '\n' {
+				line = line + "\n"
 			}
+			fmt.Fprint(os.Stdout, line)
 		}
 	}()
 

--- a/ctx.go
+++ b/ctx.go
@@ -106,7 +106,7 @@ type Ctx struct {
 	*MatcherSet
 	caretPosition       int
 	enableSep           bool
-	result              []Match
+	resultCh            chan Match
 	mutex               sync.Locker
 	currentLine         int
 	currentPage         *PageInfo
@@ -157,7 +157,7 @@ func NewCtx(o CtxOptions) *Ctx {
 		FilterQuery:         &FilterQuery{[]rune{}, newMutex()},
 		MatcherSet:          nil,
 		caretPosition:       0,
-		result:              []Match{},
+		resultCh:            nil,
 		mutex:               newMutex(),
 		currentPage:         &PageInfo{0, 1, 0},
 		maxPage:             0,
@@ -321,8 +321,8 @@ func (c *Ctx) GetCurrentAt(i int) Match {
 	return c.current[i]
 }
 
-func (c *Ctx) Result() []Match {
-	return c.result
+func (c *Ctx) ResultCh() <-chan Match {
+	return c.resultCh
 }
 
 func (c *Ctx) AddWaitGroup(v int) {


### PR DESCRIPTION
Use a channel instead of an array -- no reason, really, but all those
seemingly duplicate []Match declarations were starting to annoy me
