### PR TITLE
Owner drawing tab

### DIFF
--- a/layout.go
+++ b/layout.go
@@ -66,8 +66,16 @@ func printScreen(x, y int, fg, bg termbox.Attribute, msg string, fill bool) {
 			w = 1
 		}
 		msg = msg[w:]
-		screen.SetCell(x, y, c, fg, bg)
-		x += runewidth.RuneWidth(c)
+		if c == '\t' {
+			n := 4 - x % 4
+			for i := 0; i <= n; i++ {
+				screen.SetCell(x + i, y, ' ', fg, bg)
+			}
+			x += n
+		} else {
+			screen.SetCell(x, y, c, fg, bg)
+			x += runewidth.RuneWidth(c)
+		}
 	}
 
 	if !fill {


### PR DESCRIPTION
Currently, tab is handled as single width character.

![](http://go-gyazo.appspot.com/9f37190880c9983c.png)

Below is a patch to draw own-self.

![](http://go-gyazo.appspot.com/58ef85e1c9aaa2b1.png)
