### PR TITLE
Implement peco.ToggleQuery as Ctrl-t

### DIFF
--- a/action.go
+++ b/action.go
@@ -123,6 +123,7 @@ func init() {
 	}).Register("CancelSelectMode")
 	ActionFunc(doToggleRangeMode).Register("ToggleRangeMode")
 	ActionFunc(doCancelRangeMode).Register("CancelRangeMode")
+	ActionFunc(doToggleQuery).Register("ToggleQuery", termbox.KeyCtrlT)
 	ActionFunc(doRefreshScreen).Register("RefreshScreen", termbox.KeyCtrlL)
 
 	ActionFunc(doKonamiCommand).RegisterKeySequence(
@@ -557,6 +558,27 @@ func doDeleteBackwardChar(i *Input, ev termbox.Event) {
 
 func doRefreshScreen(i *Input, _ termbox.Event) {
 	i.ExecQuery()
+}
+
+func doToggleQuery(i *Input, _ termbox.Event) {
+	q := i.Query()
+	if len(q) == 0 {
+		sq := i.SavedQuery()
+		if len(sq) == 0 {
+			return
+		}
+		i.SetQuery(sq)
+		i.SetSavedQuery([]rune{})
+	} else {
+		i.SetSavedQuery(q)
+		i.SetQuery([]rune{})
+	}
+
+	if i.ExecQuery() {
+		return
+	}
+	i.SetCurrent(nil)
+	i.DrawMatches(nil)
 }
 
 func doKonamiCommand(i *Input, ev termbox.Event) {

--- a/ctx.go
+++ b/ctx.go
@@ -62,6 +62,7 @@ func (p *Ctx) MoveCaretPos(offset int) {
 
 type FilterQuery struct {
 	query []rune
+	savedQuery []rune
 	mutex sync.Locker
 }
 
@@ -69,6 +70,12 @@ func (q FilterQuery) Query() []rune {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 	return q.query[:]
+}
+
+func (q FilterQuery) SavedQuery() []rune {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+	return q.savedQuery[:]
 }
 
 func (q FilterQuery) QueryString() string {
@@ -154,7 +161,7 @@ func (m *loggingMutex) Unlock() {
 func NewCtx(o CtxOptions) *Ctx {
 	c := &Ctx{
 		Hub:                 NewHub(),
-		FilterQuery:         &FilterQuery{[]rune{}, newMutex()},
+		FilterQuery:         &FilterQuery{[]rune{}, []rune{}, newMutex()},
 		MatcherSet:          nil,
 		caretPosition:       0,
 		resultCh:            nil,
@@ -376,6 +383,12 @@ func (c *Ctx) NewInput() *Input {
 	k := NewKeymap(c.config.Keymap, c.config.Action)
 	k.ApplyKeybinding()
 	return &Input{c, newMutex(), nil, k, []string{}}
+}
+
+func (c *Ctx) SetSavedQuery(q []rune) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.FilterQuery.savedQuery = q
 }
 
 func (c *Ctx) SetQuery(q []rune) {


### PR DESCRIPTION
refs #202

Currently the only thing it does is to turn the query off when
there is one, and back on. If there's no query specified, it doesn't
do anything.

Caveats on this incarnation:
- Turning a query "on" means the query is re-executed. If the filter
  being applied is time consuming, it might be annoying
- Selections are not remembered. If you have selected lines while
  the query is on, it won't be re-instated when you turn it off and
  then on again
