### PR TITLE
Don't barf even if the config file is empty, or has no content

### DIFF
--- a/cmd/peco/peco.go
+++ b/cmd/peco/peco.go
@@ -169,7 +169,7 @@ func main() {
 	if opts.OptRcfile != "" {
 		err = ctx.ReadConfig(opts.OptRcfile)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
+			fmt.Fprintf(os.Stderr, "Failed to read config file %s: %s\n", opts.OptRcfile, err)
 			st = 1
 			return
 		}

--- a/cmd/peco/peco.go
+++ b/cmd/peco/peco.go
@@ -169,7 +169,7 @@ func main() {
 	if opts.OptRcfile != "" {
 		err = ctx.ReadConfig(opts.OptRcfile)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to read config file %s: %s\n", opts.OptRcfile, err)
+			fmt.Fprintf(os.Stderr, "Failed to read config file %q: %s\n", opts.OptRcfile, err)
 			st = 1
 			return
 		}

--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package peco
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,17 +49,14 @@ func (c *Config) ReadFilename(filename string) error {
 	}
 	defer f.Close()
 
-	fi, err := f.Stat()
-	if err != nil {
-		return err
-	}
-
-	if fi.Size() == 0 {
-		return nil
-	}
-
 	err = json.NewDecoder(f).Decode(c)
 	if err != nil {
+		if err == io.EOF {
+			// If it got here, then the file did not contain any parsable
+			// JSON characters. It's okay. Just ignore
+			return nil
+		}
+
 		return err
 	}
 

--- a/config.go
+++ b/config.go
@@ -48,6 +48,15 @@ func (c *Config) ReadFilename(filename string) error {
 	}
 	defer f.Close()
 
+	fi, err := f.Stat()
+	if err != nil {
+		return err
+	}
+
+	if fi.Size() == 0 {
+		return nil
+	}
+
 	err = json.NewDecoder(f).Decode(c)
 	if err != nil {
 		return err

--- a/config_test.go
+++ b/config_test.go
@@ -122,3 +122,18 @@ func TestLocateRcfile(t *testing.T) {
 	LocateRcfile()
 
 }
+
+func TestEmptyConfig(t *testing.T) {
+	// Create a dummy config file. Must be empty
+	f, err := ioutil.TempFile("", "pecoCmdTest")
+	if err != nil {
+		t.Errorf("Failed to create temporary file: %s", err)
+		return
+	}
+	defer f.Close()
+	defer os.Remove(f.Name())
+	c := NewConfig()
+	if err := c.ReadFilename(f.Name()); err != nil {
+		t.Errorf("Reading an empty config file should not cause an error")
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -134,6 +134,46 @@ func TestEmptyConfig(t *testing.T) {
 	defer os.Remove(f.Name())
 	c := NewConfig()
 	if err := c.ReadFilename(f.Name()); err != nil {
-		t.Errorf("Reading an empty config file should not cause an error")
+		t.Errorf("Reading an empty config file should not cause an error, but got: %s", err)
 	}
 }
+
+func TestWhiteSpaceOnlyConfig(t *testing.T) {
+	// Create a dummy config file. Must be empty
+	f, err := ioutil.TempFile("", "pecoCmdTest")
+	if err != nil {
+		t.Errorf("Failed to create temporary file: %s", err)
+		return
+	}
+	defer f.Close()
+	defer os.Remove(f.Name())
+
+	f.WriteString(`  `)
+	f.Sync()
+
+	c := NewConfig()
+	if err := c.ReadFilename(f.Name()); err != nil {
+		t.Errorf("Reading a config file with just whitespaces should not cause an error, but got: %s", err)
+	}
+}
+
+func TestBadConfig(t *testing.T) {
+	// Create a dummy config file. Must be empty
+	f, err := ioutil.TempFile("", "pecoCmdTest")
+	if err != nil {
+		t.Errorf("Failed to create temporary file: %s", err)
+		return
+	}
+	defer f.Close()
+	defer os.Remove(f.Name())
+
+	f.WriteString(` {  `)
+	f.Sync()
+
+	c := NewConfig()
+	if err := c.ReadFilename(f.Name()); err == nil {
+		t.Errorf("Reading a config file bad JSON should cause an error")
+	}
+}
+
+


### PR DESCRIPTION
peco may not be configured properly, but it shouldn't just exit just because the config file was empty.
