### PR TITLE
Add keep selection feature

### DIFF
--- a/action.go
+++ b/action.go
@@ -174,6 +174,9 @@ func doRotateMatcher(i *Input, ev termbox.Event) {
 }
 
 func doToggleSelection(i *Input, _ termbox.Event) {
+	if i.IsCurrentEmpty() {
+		return
+	}
 	l := i.GetCurrentAt(i.currentLine - 1)
 	if i.selection.Has(l.Index()) {
 		i.selection.Remove(l.Index())
@@ -220,7 +223,7 @@ func doSelectVisible(i *Input, _ termbox.Event) {
 
 func doFinish(i *Input, _ termbox.Event) {
 	// Must end with all the selected lines.
-	if i.SelectionLen() == 0 {
+	if i.SelectionLen() == 0 && !i.IsCurrentEmpty() {
 		l := i.GetCurrentAt(i.currentLine - 1)
 		i.SelectionAdd(l.Index())
 	}

--- a/action.go
+++ b/action.go
@@ -174,11 +174,12 @@ func doRotateMatcher(i *Input, ev termbox.Event) {
 }
 
 func doToggleSelection(i *Input, _ termbox.Event) {
-	if i.selection.Has(i.currentLine) {
-		i.selection.Remove(i.currentLine)
+	l := i.GetCurrentAt(i.currentLine - 1)
+	if i.selection.Has(l.Index()) {
+		i.selection.Remove(l.Index())
 		return
 	}
-	i.selection.Add(i.currentLine)
+	i.selection.Add(l.Index())
 }
 
 func doToggleRangeMode(i *Input, _ termbox.Event) {
@@ -220,19 +221,20 @@ func doSelectVisible(i *Input, _ termbox.Event) {
 func doFinish(i *Input, _ termbox.Event) {
 	// Must end with all the selected lines.
 	if i.SelectionLen() == 0 {
-		i.SelectionAdd(i.currentLine)
+		l := i.GetCurrentAt(i.currentLine - 1)
+		i.SelectionAdd(l.Index())
 	}
 
 	i.resultCh = make(chan Line)
 	go func() {
-		max := i.GetCurrentLen()
+		max := i.GetLinesCount()
 		for x := 1; x <= max; x++ {
-			if x > i.GetCurrentLen() {
+			if x > i.GetLinesCount() {
 				break
 			}
 
 			if i.selection.Has(x) {
-				i.resultCh <- i.GetCurrentAt(x - 1)
+				i.resultCh <- i.GetLineAt(x - 1)
 			}
 		}
 		close(i.resultCh)

--- a/ctx.go
+++ b/ctx.go
@@ -314,6 +314,10 @@ func (c *Ctx) GetCurrentLen() int {
 	return len(c.current)
 }
 
+func (c *Ctx) IsCurrentEmpty() bool {
+	return c.GetCurrentLen() <= 0
+}
+
 func (c *Ctx) SetCurrent(newMatches []Line) {
 	c.currentMutex.Lock()
 	defer c.currentMutex.Unlock()

--- a/ctx.go
+++ b/ctx.go
@@ -250,6 +250,16 @@ func (c *Ctx) GetLinesCount() int {
 	return len(c.lines)
 }
 
+func (c *Ctx) GetLineAt(i int) Line {
+	c.currentMutex.Lock()
+	defer c.currentMutex.Unlock()
+
+	if i < 0 || len(c.lines) <= i {
+		panic(fmt.Sprintf("GetCurrentAt: index out of range (%d)", i))
+	}
+	return c.lines[i]
+}
+
 func (c *Ctx) IsBufferOverflowing() bool {
 	if c.bufferSize <= 0 {
 		return false

--- a/filter.go
+++ b/filter.go
@@ -17,7 +17,6 @@ func (f *Filter) Work(cancel chan struct{}, q HubReq) {
 	}
 	f.SetCurrent(f.Matcher().Line(cancel, query, f.Buffer()))
 	f.SendStatusMsg("")
-	f.SelectionClear()
 	f.DrawMatches(nil)
 }
 

--- a/layout.go
+++ b/layout.go
@@ -324,7 +324,7 @@ func (l *ListArea) Draw(targets []Line, perPage int) {
 		case n+currentPage.offset == l.currentLine-1:
 			fgAttr = l.config.Style.SelectedFG()
 			bgAttr = l.config.Style.SelectedBG()
-		case l.SelectionContains(n + currentPage.offset + 1):
+		case l.SelectionContains(target.Index()):
 			fgAttr = l.config.Style.SavedSelectionFG()
 			bgAttr = l.config.Style.SavedSelectionBG()
 		default:

--- a/layout.go
+++ b/layout.go
@@ -307,18 +307,6 @@ func (l *ListArea) Draw(targets []Line, perPage int) {
 	var y int
 	var fgAttr, bgAttr termbox.Attribute
 	for n := 0; n < perPage; n++ {
-		switch {
-		case n+currentPage.offset == l.currentLine-1:
-			fgAttr = l.config.Style.SelectedFG()
-			bgAttr = l.config.Style.SelectedBG()
-		case l.SelectionContains(n + currentPage.offset + 1):
-			fgAttr = l.config.Style.SavedSelectionFG()
-			bgAttr = l.config.Style.SavedSelectionBG()
-		default:
-			fgAttr = l.config.Style.BasicFG()
-			bgAttr = l.config.Style.BasicBG()
-		}
-
 		targetIdx := currentPage.offset + n
 		if targetIdx >= len(targets) {
 			break
@@ -331,6 +319,19 @@ func (l *ListArea) Draw(targets []Line, perPage int) {
 		}
 
 		target := targets[targetIdx]
+
+		switch {
+		case n+currentPage.offset == l.currentLine-1:
+			fgAttr = l.config.Style.SelectedFG()
+			bgAttr = l.config.Style.SelectedBG()
+		case l.SelectionContains(n + currentPage.offset + 1):
+			fgAttr = l.config.Style.SavedSelectionFG()
+			bgAttr = l.config.Style.SavedSelectionBG()
+		default:
+			fgAttr = l.config.Style.BasicFG()
+			bgAttr = l.config.Style.BasicBG()
+		}
+
 		line := target.DisplayString()
 		matches := target.Indices()
 		if matches == nil {

--- a/line.go
+++ b/line.go
@@ -18,6 +18,7 @@ type Line interface {
 	DisplayString() string // Line to be displayed
 	Output() string        // Output string to be displayed after peco is done
 	Indices() [][]int      // If the type allows, indices into matched portions of the string
+	Index() int            // Index in lines
 }
 
 // baseLine is the common implementation between RawLine and MatchedLine
@@ -25,13 +26,15 @@ type baseLine struct {
 	buf           string
 	sepLoc        int
 	displayString string
+	idx           int
 }
 
-func newBaseLine(v string, enableSep bool) *baseLine {
+func newBaseLine(v string, idx int, enableSep bool) *baseLine {
 	m := &baseLine{
 		v,
 		-1,
 		"",
+		idx,
 	}
 	if !enableSep {
 		return m
@@ -72,6 +75,10 @@ func (m baseLine) Output() string {
 	return m.buf
 }
 
+func (m baseLine) Index() int {
+	return m.idx
+}
+
 // RawLine implements the Line interface. It represents a line with no matches,
 // which means that it can only be used in the initial unfiltered view
 type RawLine struct {
@@ -79,8 +86,8 @@ type RawLine struct {
 }
 
 // NewRawLine creates a RawLine struct
-func NewRawLine(v string, enableSep bool) *RawLine {
-	return &RawLine{newBaseLine(v, enableSep)}
+func NewRawLine(v string, idx int, enableSep bool) *RawLine {
+	return &RawLine{newBaseLine(v, idx, enableSep)}
 }
 
 // Indices always returns nil
@@ -96,8 +103,8 @@ type MatchedLine struct {
 }
 
 // NewMatchedLine creates a new MatchedLine struct
-func NewMatchedLine(v string, enableSep bool, m [][]int) *MatchedLine {
-	return &MatchedLine{newBaseLine(v, enableSep), m}
+func NewMatchedLine(v string, idx int, enableSep bool, m [][]int) *MatchedLine {
+	return &MatchedLine{newBaseLine(v, idx, enableSep), m}
 }
 
 // Indices returns the indices in the buffer that matched

--- a/line.go
+++ b/line.go
@@ -19,6 +19,7 @@ type Line interface {
 	Output() string        // Output string to be displayed after peco is done
 	Indices() [][]int      // If the type allows, indices into matched portions of the string
 	Index() int            // Index in lines
+	SetIndex(int)          // Set index in lines
 }
 
 // baseLine is the common implementation between RawLine and MatchedLine
@@ -77,6 +78,10 @@ func (m baseLine) Output() string {
 
 func (m baseLine) Index() int {
 	return m.idx
+}
+
+func (m *baseLine) SetIndex(idx int) {
+	m.idx = idx
 }
 
 // RawLine implements the Line interface. It represents a line with no matches,

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -28,7 +28,7 @@ func TestANSIColorStrip(t *testing.T) {
 func TestNewMatch(t *testing.T) {
 	var m Line
 
-	m = NewRawLine("Hello, World!", false)
+	m = NewRawLine("Hello, World!", 1, false)
 	if m.Indices() != nil {
 		t.Errorf("NoMatch.Indices() must always return nil")
 	}
@@ -56,11 +56,11 @@ func TestNewMatch(t *testing.T) {
 	}
 
 	makeDidMatch := func(buf string) (string, Line) {
-		return buf, NewMatchedLine(buf, true, [][]int{{0, 5}})
+		return buf, NewMatchedLine(buf, 1, true, [][]int{{0, 5}})
 	}
 
 	makeNoMatch := func(buf string) (string, Line) {
-		return buf, NewRawLine(buf, true)
+		return buf, NewRawLine(buf, 1, true)
 	}
 
 	nullsepCheck(makeNoMatch("Hello, World!"))

--- a/reader.go
+++ b/reader.go
@@ -67,7 +67,7 @@ func (b *BufferReader) Loop() {
 
 				// Make sure we lock access to b.lines
 				m.Lock()
-				b.SetLines(append(b.GetLines(), NewRawLine(line, b.enableSep)))
+				b.SetLines(append(b.GetLines(), NewRawLine(line, b.GetLinesCount()+1, b.enableSep)))
 				if b.IsBufferOverflowing() {
 					lines := b.GetLines()
 					b.SetLines(lines[1:])

--- a/reader.go
+++ b/reader.go
@@ -50,6 +50,7 @@ func (b *BufferReader) Loop() {
 	once := &sync.Once{}
 	var refresh *time.Timer
 
+	overflow := false
 	loop := true
 	for loop {
 		select {
@@ -71,6 +72,7 @@ func (b *BufferReader) Loop() {
 				if b.IsBufferOverflowing() {
 					lines := b.GetLines()
 					b.SetLines(lines[1:])
+					overflow = true
 				}
 				m.Unlock()
 			}
@@ -97,5 +99,11 @@ func (b *BufferReader) Loop() {
 	if b.GetLinesCount() == 0 {
 		b.ExitWith(1)
 		fmt.Fprintf(os.Stderr, "No buffer to work with was available")
+	}
+
+	if overflow {
+		for i, line := range b.GetLines() {
+			line.SetIndex(i + 1)
+		}
 	}
 }


### PR DESCRIPTION
![peco-keep-selection](https://cloud.githubusercontent.com/assets/9955/6429602/153add1a-c021-11e4-86e0-44b76be0f7e1.gif)

# Brief

I propose keep selection feature.
Merge this patch then selection is kept when applied new query.
Thus we select multi line with incremental search.

# Use case

1. Open multi file from huge `git ls-file` result.
2. Select multi language from `gibo -l` result ([simonwhitaker/gibo](https://github.com/simonwhitaker/gibo))
3. Open more than one directories in separated pane with tmux.

thank you.