### PR TITLE
Support 256color

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Below are configuration sections that you may specify in your config file:
 * [CustomMatcher](#custommatcher)
 * [Prompt](#prompt)
 * [InitialMatcher](#initialmatcher)
+* [Use256Color](#use256color)
 
 ## Keymaps
 
@@ -379,6 +380,7 @@ For now, styles of following 5 items can be customized in `config.json`.
 - `"magenta"` for `termbox.ColorMagenta`
 - `"cyan"` for `termbox.ColorCyan`
 - `"white"` for `termbox.ColorWhite`
+- `"0"`-`"255"` for 256color (these colors need [Use256Color](#use256color) is set to `true`)
 
 ### Background Colors
 
@@ -390,6 +392,7 @@ For now, styles of following 5 items can be customized in `config.json`.
 - `"on_magenta"` for `termbox.ColorMagenta`
 - `"on_cyan"` for `termbox.ColorCyan`
 - `"on_white"` for `termbox.ColorWhite`
+- `"on_0"`-`"on_255"` for 256color (these colors need [Use256Color](#use256color) is set to `true`)
 
 ### Attributes
 
@@ -444,6 +447,18 @@ Note: `Matcher` key has been deprecated in favor of `InitialMatcher`. `Matcher` 
 ## Layout
 
 See --layout.
+
+## Use256Color
+
+Boolean value that determines whether or not to use 256color. The default is `false`.
+
+Note: This has no effect on Windows because Windows console does not support extra color modes.
+
+```json
+{
+    "Use256Color": true
+}
+```
 
 Hacking
 =======

--- a/build/make.go
+++ b/build/make.go
@@ -38,7 +38,7 @@ func setupDeps() {
 	deps := map[string]string{
 		"github.com/jessevdk/go-flags":  "8ec9564882e7923e632f012761c81c46dcf5bec1",
 		"github.com/mattn/go-runewidth": "63c378b851290989b19ca955468386485f118c65",
-		"github.com/nsf/termbox-go":     "bb19a81afd4bc2729799d1fedb19f7bd7ee284cf",
+		"github.com/nsf/termbox-go":     "9e7f2135126fcf13f331e7b24f5d66fd8e8e1690",
 	}
 
 	var err error

--- a/cmd/peco/peco.go
+++ b/cmd/peco/peco.go
@@ -217,6 +217,12 @@ func main() {
 	}
 	defer termbox.Close()
 
+	if ctx.IsUse256Color() {
+		// This has no effect on Windows,
+		// because termbox.SetOutputMode always sets termbox.OutputNormal on Windows.
+		termbox.SetOutputMode(termbox.Output256)
+	}
+
 	// Windows handle Esc/Alt self
 	if runtime.GOOS == "windows" {
 		termbox.SetInputMode(termbox.InputEsc | termbox.InputAlt)

--- a/config_test.go
+++ b/config_test.go
@@ -62,6 +62,10 @@ func TestStringsToStyle(t *testing.T) {
 			strings: []string{"on_bold", "on_magenta", "green"},
 			style:   &Style{fg: termbox.ColorGreen, bg: termbox.ColorMagenta | termbox.AttrBold},
 		},
+		stringsToStyleTest{
+			strings: []string{"underline", "on_240", "214"},
+			style:   &Style{fg: (214+1) | termbox.AttrUnderline, bg: 240+1},
+		},
 	}
 
 	t.Logf("Checking strings -> color mapping...")

--- a/ctx.go
+++ b/ctx.go
@@ -419,6 +419,10 @@ func (c *Ctx) LoadCustomMatcher() error {
 	return nil
 }
 
+func (c *Ctx) IsUse256Color() bool {
+	return c.config.Use256Color
+}
+
 func (c *Ctx) ExitWith(i int) {
 	c.exitStatus = i
 	c.Stop()


### PR DESCRIPTION
256 color requires a newer version of termbox-go. (256 color support has been implemented since nsf/termbox-go@5c29885377d74da8866fac8477fbd261c87fc491.)

This has no effect on Windows because Windows console does not support extra color modes. (cf. nsf/termbox-go@23d1941b3f6b76577e06d80827a3407b600f3765)

Screenshot: ![peco-256color](https://cloud.githubusercontent.com/assets/850677/6458394/47759382-c1c6-11e4-8adf-a730544704af.png)