### PR TITLE
handle ansi escape sequences

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -88,7 +88,7 @@ func NewCtx(enableSep bool) *Ctx {
 		make(chan struct{}),         // loopCh. You never send messages to this. no point in buffering
 		make(chan string, 5),        // queryCh.
 		make(chan []Match, 5),       // drawCh.
-		make(chan string, 5),				 // statusMsgCh
+		make(chan string, 5),        // statusMsgCh
 		make(chan PagingRequest, 5), // pagingCh
 		sync.Mutex{},
 		[]rune{},

--- a/view.go
+++ b/view.go
@@ -199,17 +199,23 @@ CALCULATE_PAGE:
 		target := targets[targetIdx]
 		line := target.Line()
 		matches := target.Indices()
+		fgs, bgs := target.Attribs()
 		if matches == nil {
-			printTB(0, n, fgAttr, bgAttr, line)
+			prev := 0
+			for i, c := range line {
+				printTB(prev, n, fgAttr|fgs[i], bgAttr|bgs[i], string(c))
+				prev += runewidth.StringWidth(string(c))
+			}
 		} else {
 			prev := 0
 			index := 0
 			for _, m := range matches {
 				if m[0] > index {
-					c := line[index:m[0]]
-					printTB(prev, n, fgAttr, bgAttr, c)
-					prev += runewidth.StringWidth(c)
-					index += len(c)
+					for i, c := range line[index:m[0]] {
+						printTB(prev, n, fgAttr|fgs[index+i], bgAttr|bgs[index+i], string(c))
+						prev += runewidth.StringWidth(string(c))
+					}
+					index += m[0] - index
 				}
 				c := line[m[0]:m[1]]
 				printTB(prev, n, v.config.Style.Query.fg, bgAttr|v.config.Style.Query.bg, c)


### PR DESCRIPTION
Addresses #188. This is a quick first hack just to convince myself I could figure out how to do it.  If it seems like a reasonable direction, I can work to polish it up, and make sure byte vs rune indexing is handled sufficiently carefully.

This increases the memory-size of all match objects by a factor of 4x or so - not sure how acceptable that is to your goals.  Extra space usage is in MatchString from:

* a duplicate buffer in MatchString that has the ansi sequences filtered out
* fg and bg termbox.Attribute for each byte in the filtered buffer.

As a consequence of these changes, the view rendering also has to run rune by rune.