### PR TITLE
Fix send query twice when QueryExecutionDelay is 0

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -275,6 +275,7 @@ func (c *Ctx) ExecQuery() bool {
 
 	if delay <= 0 {
 		c.SendQuery(c.QueryString())
+		return true
 	}
 
 	go func() {


### PR DESCRIPTION
![peco-send-query-twice](https://cloud.githubusercontent.com/assets/9955/6798223/50e2f214-d24e-11e4-800b-845a6512137b.gif)

I found wrong filtered result :astonished:
It because send filter query twice at same time when `QueryExecutionDelay` is 0.

Thanks