### PR TITLE
Fix not highlighting issue

### DIFF
--- a/action.go
+++ b/action.go
@@ -223,11 +223,13 @@ func doSelectAll(i *Input, _ termbox.Event) {
 	b := i.GetCurrentLineBuffer()
 	for x := 0; x < b.Size(); x++ {
 		if l, err := b.LineAt(x); err == nil {
+			l.SetDirty(true)
 			i.selection.Add(l)
 		} else {
 			i.selection.Remove(l)
 		}
 	}
+	i.SendDraw()
 }
 
 func doSelectVisible(i *Input, _ termbox.Event) {


### PR DESCRIPTION
I assigned `peco.SelectAll` to `C-k`

## Original
![before](https://cloud.githubusercontent.com/assets/554281/9376283/d33c5400-4745-11e5-8cd5-9af7627e2e23.gif)

Items are not highlighted when I call `SelectAll` however they are selected(Output is all lines). And items are highlighted when I move cursor etc.

## Fixed version
![after](https://cloud.githubusercontent.com/assets/554281/9376286/d8dc40b4-4745-11e5-8ca6-9e27d5ee3295.gif)
