### PR TITLE
[RFC] Execute command

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,23 @@ See --layout.
 }
 ```
 
+## ExecuteCommand
+
+```
+{
+  "Keymap": {
+    "C-e": "peco.ExecuteCommand.Notepad"
+  },
+  "Command": [
+    {
+      "Name": "Notepad",
+      "Args": ["notepad", "$FILE"],
+      "Spawn": true
+    }
+  ]
+}
+```
+
 Hacking
 =======
 

--- a/action.go
+++ b/action.go
@@ -703,9 +703,6 @@ func makeCommandAction(cc *CommandConfig) ActionFunc {
 			}
 			i.SendStatusMsg("Executing " + cc.Name)
 			cmd := exec.Command(args[0], args[1:]...)
-			cmd.Stdin = os.Stdin
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
 			if cc.Spawn {
 				err = cmd.Start()
 				go func() {
@@ -713,8 +710,12 @@ func makeCommandAction(cc *CommandConfig) ActionFunc {
 					os.Remove(f.Name())
 				}()
 			} else {
+				cmd.Stdin = os.Stdin
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
 				err = cmd.Run()
 				os.Remove(f.Name())
+				i.ExecQuery()
 			}
 			if err != nil {
 				return false

--- a/ctx.go
+++ b/ctx.go
@@ -128,6 +128,15 @@ func (c *Ctx) populateSingleKeyJumpPrefixList() {
 	}
 }
 
+func (c *Ctx) populateCommandList() {
+	for _, v := range c.config.Command {
+		if len(v.Args) == 0 {
+			continue
+		}
+		makeCommandAction(&v).Register("ExecuteCommand." + v.Name)
+	}
+}
+
 const invalidSelectionRange = -1
 
 func (c *Ctx) ReadConfig(file string) error {
@@ -148,6 +157,8 @@ func (c *Ctx) ReadConfig(file string) error {
 	}
 
 	c.populateSingleKeyJumpPrefixList()
+
+	c.populateCommandList()
 
 	return nil
 }

--- a/interface.go
+++ b/interface.go
@@ -340,6 +340,7 @@ type Config struct {
 	Layout              string            `json:"Layout"`
 	CustomMatcher       map[string][]string
 	CustomFilter        map[string]CustomFilterConfig
+	Command             []CommandConfig
 	QueryExecutionDelay int
 	StickySelection     bool
 
@@ -352,6 +353,17 @@ type SingleKeyJumpConfig struct {
 	ShowPrefix bool          `json:"ShowPrefix"`
 	PrefixList []rune        `json:"-"`
 	PrefixMap  map[rune]uint `json:"-"`
+}
+
+type CommandConfig struct {
+	// Name is the name of the command to execute
+	Name string
+
+	// TODO: need to check if how we use this is correct
+	Args []string
+
+	// Spawn mean the command should be executed asynchronous.
+	Spawn bool
 }
 
 // CustomFilterConfig is used to specify configuration parameters


### PR DESCRIPTION
peco quit with `peco.Finish` command. i.e. peco can provide one action for command-line that user specified.
But I'm thinking peco may be possible to provide more useful actions if peco execute external command. This is work in progress. I want to see your comments.

For example, doing `ls | peco` should be list of file names. Below works application launcher to exxecute windows notepad.
```
{
  "Keymap": {
    "C-e": "peco.ExecuteCommand.Notepad"
  },
  "Command": [
    {
      "Name": "Notepad",
      "Args": ["notepad", "$FILE"],
      "Spawn": true
    }
  ]
}
```

And also, I'm thinking this may solve #270 with assigning `less` command to display whole line.

any thought?