### PR TITLE
Don't change line if there is no output

### DIFF
--- a/layout.go
+++ b/layout.go
@@ -351,7 +351,7 @@ func (l *ListArea) Draw(parent Layout, perPage int, runningQuery bool) {
 
 	// This protects us from losing the selected line in case our selected
 	// line is greater than the buffer
-	if lbufsiz := linebuf.Size(); l.currentLine >= lbufsiz {
+	if lbufsiz := linebuf.Size(); lbufsiz > 0 && l.currentLine >= lbufsiz {
 		l.currentLine = lbufsiz - 1
 	}
 


### PR DESCRIPTION
l.currentLine is set `-1` if `linebuf.Size()` is zero.

This is related to #273.

#### Current
(I suppose this issue cannot be reproduced with slow typing)

![before](https://cloud.githubusercontent.com/assets/554281/10260780/a23589e0-69b8-11e5-9a4a-ab937fbb55a8.gif)

#### Fixed

![after](https://cloud.githubusercontent.com/assets/554281/10260782/ac0beb76-69b8-11e5-9bdd-26561f00755a.gif)

