### PR TITLE
fix bug in byMatchStart.Less()

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -81,7 +81,7 @@ func (m byMatchStart) Less(i, j int) bool {
 	}
 
 	if m[i][0] == m[j][0] {
-		return m[i][1]-m[i][0] < m[i][1]-m[i][0]
+		return m[i][1]-m[i][0] < m[j][1]-m[j][0]
 	}
 
 	return false


### PR DESCRIPTION
Foud by https://github.com/dominikh/go-staticcheck

filter.go:84:10: identical expressions on the left and right side of the '<' operator