### PR TITLE
Move handling collecting results out of the context

### DIFF
--- a/action.go
+++ b/action.go
@@ -282,24 +282,20 @@ func doSelectVisible(ctx context.Context, state *Peco, _ termbox.Event) {
 	state.Hub().SendDraw(false)
 }
 
+type errCollectResults struct{}
+func (err errCollectResults) Error() string {
+	return "collect results"
+}
+func (err errCollectResults) CollectResults() bool {
+	return true
+}
 func doFinish(ctx context.Context, state *Peco, _ termbox.Event) {
 	if pdebug.Enabled {
 		g := pdebug.Marker("doFinish")
 		defer g.End()
 	}
 
-	selection := state.Selection()
-	// Must end with all the selected lines.
-	if selection.Len() == 0 {
-		if l, err := state.CurrentLineBuffer().LineAt(state.Location().LineNumber()); err == nil {
-			selection.Add(l)
-		}
-	}
-
-	state.SetResultCh(make(chan Line))
-	go state.collectResults()
-
-	state.Exit(nil)
+	state.Exit(errCollectResults{})
 }
 
 func doCancel(ctx context.Context, state *Peco, e termbox.Event) {

--- a/filter.go
+++ b/filter.go
@@ -89,7 +89,8 @@ func (f *Filter) Work(ctx context.Context, q hub.Payload) {
 	}
 
 	if pdebug.Enabled {
-		pdebug.Printf("New query '%s'", query)
+		g := pdebug.Marker("Filter.Work query '%s'", query)
+		defer g.End()
 	}
 
 	state := f.state

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -34,11 +34,29 @@ type ignorable interface {
 	Ignorable() bool
 }
 
-func IsIgnorable(err error) bool {
+type collectResults interface {
+	CollectResults() bool
+}
+
+func IsIgnorableError(err error) bool {
 	for e := err; e != nil; {
 		switch e.(type) {
 		case ignorable:
 			return e.(ignorable).Ignorable()
+		case causer:
+			e = e.(causer).Cause()
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+func IsCollectResultsError(err error) bool {
+	for e := err; e != nil; {
+		switch e.(type) {
+		case collectResults:
+			return e.(collectResults).CollectResults()
 		case causer:
 			e = e.(causer).Cause()
 		default:

--- a/peco.go
+++ b/peco.go
@@ -563,7 +563,7 @@ func (p *Peco) ExecQuery() bool {
 	return true
 }
 
-func (p *Peco) collectResults() {
+func (p *Peco) CollectResults() {
 	// In rare cases where the result channel is not setup
 	// prior to call to this method, bail out
 	if p.resultCh == nil {

--- a/peco_test.go
+++ b/peco_test.go
@@ -139,7 +139,7 @@ func TestPecoHelp(t *testing.T) {
 	time.AfterFunc(time.Second, cancel)
 
 	err := p.Run(ctx)
-	if !assert.True(t, util.IsIgnorable(err), "p.Run() should return error with Ignorable() method, and it should return true") {
+	if !assert.True(t, util.IsIgnorableError(err), "p.Run() should return error with Ignorable() method, and it should return true") {
 		return
 	}
 }


### PR DESCRIPTION
This avoids possibly running a race condition during doFinish,
as doFinish onyl notifies that we're exiting now. Collecting the
data is now handled in the main function, after all of the
sub-goroutines are done.

fixes #321 (but only for peco > 0.3.6)