### PR TITLE
Topic/issue 320

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
   - 1.6
+  - 1.7
   - tip
 sudo: false
 install:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ VERSION=$(patsubst "%",%,$(lastword $(shell grep version peco.go)))
 RELEASE_DIR=releases
 ARTIFACTS_DIR=$(RELEASE_DIR)/artifacts/$(VERSION)
 SRC_FILES = $(wildcard *.go cmd/peco/*.go internal/*/*.go)
-HAVE_GLIDE:=$(shell which glide)
+HAVE_GLIDE:=$(shell which glide >& /dev/null)
 GITHUB_USERNAME=peco
 
 .PHONY: clean build build-windows-amd64 build-windows-386 build-linux-amd64 $(RELEASE_DIR)/$(GOOS)/$(GOARCH)/peco$(SUFFIX)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 854854a28c7bbb8124d302c88b30d65c4ed6a15eee43b9c7f32d4bf9e3cc4465
-updated: 2016-06-10T14:22:57.48783324+09:00
+updated: 2016-08-17T15:35:42.573860443+09:00
 imports:
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
@@ -10,7 +10,7 @@ imports:
 - name: github.com/jessevdk/go-flags
   version: 6b9493b3cb60367edd942144879646604089e3f7
 - name: github.com/lestrrat/go-pdebug
-  version: a45b04725d5819f9f30fb68085be53b90a1d55f1
+  version: 2e6eaaa5717f81bda41d27070d3c966f40a1e75f
 - name: github.com/mattn/go-runewidth
   version: d6bea18f789704b5f83375793155289da36a3c7f
 - name: github.com/nsf/termbox-go

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -1,6 +1,10 @@
 package hub
 
-import "time"
+import (
+	"time"
+
+	pdebug "github.com/lestrrat/go-pdebug"
+)
 
 func NewPayload(data interface{}) *payload {
 	p := &payload{data: data}
@@ -83,6 +87,8 @@ func (h *Hub) SendDrawPrompt() {
 
 // SendDraw sends a request to redraw the terminal display
 func (h *Hub) SendDraw(runningQuery bool) {
+	pdebug.Printf("START Hub.SendDraw %t", runningQuery)
+	defer pdebug.Printf("END Hub.SendDraw %t", runningQuery)
 	send(h.DrawCh(), NewPayload(runningQuery), h.isSync)
 }
 

--- a/input.go
+++ b/input.go
@@ -47,9 +47,9 @@ func (i *Input) handleInputEvent(ctx context.Context, ev termbox.Event) error {
 
 		// Smells like Esc or Alt. mod == nil checks for the presense
 		// of a previous timer
+		m.Lock()
 		if ev.Ch == 0 && ev.Key == 27 && i.mod == nil {
 			tmp := ev
-			m.Lock()
 			i.mod = time.AfterFunc(50*time.Millisecond, func() {
 				m.Lock()
 				i.mod = nil
@@ -59,6 +59,7 @@ func (i *Input) handleInputEvent(ctx context.Context, ev termbox.Event) error {
 			m.Unlock()
 			return nil
 		}
+		m.Unlock()
 
 		// it doesn't look like this is Esc or Alt. If we have a previous
 		// timer, stop it because this is probably Alt+ this new key

--- a/interface.go
+++ b/interface.go
@@ -70,7 +70,7 @@ type Peco struct {
 	// Config contains the values read in from config file
 	config                  Config
 	currentLineBuffer       Buffer
-	enableSep               bool     // Enable parsing on separators
+	enableSep               bool // Enable parsing on separators
 	filters                 FilterSet
 	idgen                   *idgen
 	initialFilter           string   // populated if --initial-filter is specified
@@ -425,7 +425,7 @@ type FilterSet struct {
 	mutex   sync.Mutex
 }
 
-// Source implements pipline.Source, and is the buffer for the input
+// Source implements pipeline.Source, and is the buffer for the input
 type Source struct {
 	pipeline.OutputChannel
 
@@ -486,9 +486,9 @@ type Buffer interface {
 
 // MemoryBuffer is an implementation of Buffer
 type MemoryBuffer struct {
-	done  chan struct{}
-	lines []Line
-	mutex sync.RWMutex
+	done         chan struct{}
+	lines        []Line
+	mutex        sync.RWMutex
 	PeriodicFunc func()
 }
 
@@ -505,8 +505,7 @@ type Input struct {
 }
 
 type LineFilter interface {
-	pipeline.ProcNode
-
+	pipeline.Acceptor
 	SetQuery(string)
 	Clone() LineFilter
 	String() string

--- a/layout.go
+++ b/layout.go
@@ -219,9 +219,12 @@ func (s *StatusBar) setClearTimer(t *time.Timer) {
 // PrintStatus prints a new status message. This also resets the
 // timer created by ClearStatus()
 func (s *StatusBar) PrintStatus(msg string, clearDelay time.Duration) {
-	s.stopTimer()
+	if pdebug.Enabled {
+		g := pdebug.Marker("StatusBar.PrintStatus")
+		defer g.End()
+	}
 
-	s.timerMutex.Lock()
+	s.stopTimer()
 
 	location := s.AnchorPosition()
 
@@ -263,8 +266,6 @@ func (s *StatusBar) PrintStatus(msg string, clearDelay time.Duration) {
 		})
 	}
 	s.screen.Flush()
-
-	s.timerMutex.Unlock()
 
 	// if everything is successful AND the clearDelay timer is specified,
 	// then set a timer to clear the status

--- a/source.go
+++ b/source.go
@@ -116,7 +116,6 @@ func (s *Source) Start(ctx context.Context, out pipeline.OutputChannel) {
 			}
 			return
 		default:
-			pdebug.Printf("Source.Start sending line")
 			out.Send(l)
 		}
 	}

--- a/source.go
+++ b/source.go
@@ -22,7 +22,6 @@ func NewSource(in io.Reader, idgen lineIDGenerator, enableSep bool) *Source {
 		ready:         make(chan struct{}),
 		setupDone:     make(chan struct{}),
 		setupOnce:     sync.Once{},
-		start:         make(chan struct{}, 1),
 		OutputChannel: pipeline.OutputChannel(make(chan interface{})),
 	}
 	s.Reset()
@@ -101,15 +100,13 @@ func (s *Source) Setup(state *Peco) {
 }
 
 // Start starts
-func (s *Source) Start(ctx context.Context) {
+func (s *Source) Start(ctx context.Context, out pipeline.OutputChannel) {
 	// I should be the only one running this method until I bail out
 	if pdebug.Enabled {
 		g := pdebug.Marker("Source.Start")
 		defer g.End()
 		defer pdebug.Printf("Source sent %d lines", len(s.lines))
 	}
-	s.start <- struct{}{}
-	defer func() { <-s.start }()
 
 	for _, l := range s.lines {
 		select {
@@ -119,10 +116,11 @@ func (s *Source) Start(ctx context.Context) {
 			}
 			return
 		default:
-			s.OutputChannel.Send(l)
+			pdebug.Printf("Source.Start sending line")
+			out.Send(l)
 		}
 	}
-	s.OutputChannel.SendEndMark("end of input")
+	out.SendEndMark("end of input")
 }
 
 // Reset resets the state of the source object so that it


### PR DESCRIPTION
Hopefully, this fixes #320.

Basically, the Source was written so that it expected to be used by only one goroutine at any given time. However, if we want to execute filters in succession on large enough buffers, this becomes a blocking operation.

This has been fixed by changing the pipeline interface to not rely on object state, but rather use ephemeral parameters for Accept()/Start() methods