### PR TITLE
Clone idgen field too

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -445,6 +445,7 @@ func (ecf ExternalCmdFilter) Clone() LineFilter {
 		args:            ecf.args,
 		cmd:             ecf.cmd,
 		enableSep:       ecf.enableSep,
+		idgen:           ecf.idgen,
 		name:            ecf.name,
 		outCh:           pipeline.OutputChannel(make(chan interface{})),
 		thresholdBufsiz: ecf.thresholdBufsiz,


### PR DESCRIPTION
This is related to #328.
If `idgen` field is nil, [this line](https://github.com/peco/peco/blob/87b4ad48a0638cbc1421a00cd87a524c93e9bed4/filter.go#L563) raises panic(null pointer exception).