### PR TITLE
Fix that 'InitialFilter' configuration does not affect

### DIFF
--- a/peco.go
+++ b/peco.go
@@ -495,6 +495,8 @@ func (p *Peco) ApplyConfig(opts CLIOptions) error {
 		p.initialFilter = opts.OptInitialMatcher
 	} else if len(opts.OptInitialFilter) > 0 {
 		p.initialFilter = opts.OptInitialFilter
+	} else if p.config.InitialFilter != "" {
+		p.initialFilter = p.config.InitialFilter
 	}
 
 	if v := p.initialFilter; v != "" {


### PR DESCRIPTION
Current (v0.4.2) peco doesn't refrect `InitialFilter` configuration properly.  When I set `SmartCase` to `~/.config/peco/config.json`, peco always selects `IgnoreCase` as its filter.

```json
{
    "InitialFilter": "SmartCase",
}
```

I fixed this by applying JSON config properly.