### PR TITLE
Add notion of "top-level" actions

### DIFF
--- a/hub/hub.go
+++ b/hub/hub.go
@@ -39,10 +39,16 @@ func New(bufsiz int) *Hub {
 
 // Batch allows you to synchronously send messages during the
 // scope of f() being executed.
-func (h *Hub) Batch(f func()) {
-	// lock during this operation
-	h.mutex.Lock()
-	defer h.mutex.Unlock()
+func (h *Hub) Batch(f func(), shouldLock bool) {
+	if pdebug.Enabled {
+		g := pdebug.Marker("Batch %t", shouldLock)
+		defer g.End()
+	}
+	if shouldLock {
+		// lock during this operation
+		h.mutex.Lock()
+		defer h.mutex.Unlock()
+	}
 
 	// temporarily set isSync = true
 	o := h.isSync

--- a/hub/hub_test.go
+++ b/hub/hub_test.go
@@ -50,7 +50,7 @@ func TestHub(t *testing.T) {
 		h.SendDraw(true)
 		h.SendStatusMsg("Hello, World!")
 		h.SendPaging(1)
-	})
+	}, true)
 
 	phases := []string{
 		"query",

--- a/keymap.go
+++ b/keymap.go
@@ -25,13 +25,21 @@ func (km Keymap) Sequence() Keyseq {
 	return km.seq
 }
 
-func (km Keymap) ExecuteAction(ctx context.Context, state *Peco, ev termbox.Event) error {
+const isTopLevelActionCall = "peco.isTopLevelActionCall"
+
+func (km Keymap) ExecuteAction(ctx context.Context, state *Peco, ev termbox.Event) (err error) {
+	if pdebug.Enabled {
+		g := pdebug.Marker("Keymap.ExecuteAction %v", ev).BindError(&err)
+		defer g.End()
+	}
+
 	a := km.LookupAction(ev)
 	if a == nil {
 		return errors.New("action not found")
 	}
 
-	a.(Action).Execute(ctx, state, ev)
+	ctx = context.WithValue(ctx, isTopLevelActionCall, true)
+	a.Execute(ctx, state, ev)
 	return nil
 }
 

--- a/peco.go
+++ b/peco.go
@@ -266,6 +266,10 @@ func (p *Peco) Run(ctx context.Context) (err error) {
 		defer g.End()
 	}
 
+	// do this only once
+	var readyOnce sync.Once
+	defer readyOnce.Do(func() { close(p.readyCh) })
+
 	if err := p.Setup(); err != nil {
 		return errors.Wrap(err, "failed to setup peco")
 	}
@@ -342,7 +346,7 @@ func (p *Peco) Run(ctx context.Context) (err error) {
 		}()
 	}
 
-	close(p.readyCh)
+	readyOnce.Do(func() { close(p.readyCh) })
 
 	// This has tobe AFTER close(p.readyCh), otherwise the query is
 	// ignored by us (queries are not run until peco thinks it's ready)

--- a/peco_test.go
+++ b/peco_test.go
@@ -3,6 +3,8 @@ package peco
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"runtime"
 	"sync"
 	"testing"
@@ -44,6 +46,17 @@ func (i *interceptor) record(name string, args []interface{}) {
 	}
 
 	events[name] = append(v, interceptorArgs(args))
+}
+
+func newConfig(s string) (string, error) {
+	f, err := ioutil.TempFile("", "peco-test-config-")
+	if err != nil {
+		return "", err
+	}
+
+	io.WriteString(f, s)
+	f.Close()
+	return f.Name(), nil
 }
 
 func newPeco() *Peco {


### PR DESCRIPTION
This is used to by-pass locking the hub.Batch operation when
we have nested action calls that use batching internally.

fixes #345