### PR TITLE
Fix some lower lines are not drawn when moved from less lines page

### DIFF
--- a/layout.go
+++ b/layout.go
@@ -367,6 +367,8 @@ func (l *ListArea) Draw(state *Peco, parent Layout, perPage int, options *DrawOp
 		newCache := make([]Line, perPage)
 		copy(newCache, l.displayCache)
 		l.displayCache = newCache
+	} else if perPage > bufsiz {
+		l.displayCache = l.displayCache[:bufsiz]
 	}
 
 	var y int


### PR DESCRIPTION
Hello
I think peco has a bug from version 0.4.2.
Some lower lines are not drawn when moved from less lines page.
Please see this below.
![peco_fix01](https://cloud.githubusercontent.com/assets/1822861/19417185/5d0e3070-93e1-11e6-9c39-2520cbf852b3.gif)

It seems that caused by mistake of cache handling.

Thanks.