### PR TITLE
Implement #242: Support for fuzzy search

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The SmartCase filter uses case-*insensitive* matching when all of the queries ar
 
 The RegExp filter allows you to use any valid regular expression to match lines
 
-The Fuzzy filter allows you to find matches using partial patterns. For example, when searching for `ALongString`, you can enable the Fuzzy filter and search `ALS` to find it. The Fuzzy filter uses smart case search like the SmartCase filter. The Fuzzy filter is not enabled by default, but can be enabled using option `--enable-fuzzy`.
+The Fuzzy filter allows you to find matches using partial patterns. For example, when searching for `ALongString`, you can enable the Fuzzy filter and search `ALS` to find it. The Fuzzy filter uses smart case search like the SmartCase filter. The Fuzzy filter is not enabled by default, but can be enabled using option `--fuzzy-filter`.
 
 ![Executed `ps aux | peco`, then typed `google`, which matches the Chrome.app under IgnoreCase filter type. When you change it to Regexp filter, this is no longer the case. But you can type `(?i)google` instead to toggle case-insensitive mode](http://peco.github.io/images/peco-demo-matcher.gif)
 
@@ -225,7 +225,7 @@ You can change the query line's prompt, which is `QUERY>` by default.
 
 ### FuzzyFilter
 
-Set to `enabled` to make the Fuzzy filter available. Default is `disabled`.
+Set to `enabled` to make the Fuzzy filter available, or `disabled` to disable it. Default is `disabled`.
 
 ### InitialFilter
 

--- a/README.md
+++ b/README.md
@@ -58,13 +58,15 @@ Not only can you select multiple lines one by one, you can select a range of lin
 
 ## Select Filters
 
-Different types of filters are available. Default is case-insensitive filter, so lines with any case will match. You can toggle between IgnoreCase, CaseSensitive, SmartCase and RegExp filters. 
+Different types of filters are available. Default is case-insensitive filter, so lines with any case will match. You can toggle between IgnoreCase, CaseSensitive, SmartCase RegExp and Fuzzy filters. 
 
 The SmartCase filter uses case-*insensitive* matching when all of the queries are lower case, and case-*sensitive* matching otherwise.
 
 The RegExp filter allows you to use any valid regular expression to match lines
 
-![Executed `ps aux | peco`, then typed `google`, which matches the Chrome.app under IgnoreCase filter type. Whenyou change it to Regexp filter, this is no longer the case. But you can type `(?i)google` instead to toggle case-insensitive mode](http://peco.github.io/images/peco-demo-matcher.gif)
+The Fuzzy filter allows you to find matches using partial patterns. For example, when searching for `ALongString`, you can enable the Fuzzy filter and search `ALS` to find it. The Fuzzy filter uses smart case search like the SmartCase filter. The Fuzzy filter is not enabled by default, but can be enabled using option `--enable-fuzzy`.
+
+![Executed `ps aux | peco`, then typed `google`, which matches the Chrome.app under IgnoreCase filter type. When you change it to Regexp filter, this is no longer the case. But you can type `(?i)google` instead to toggle case-insensitive mode](http://peco.github.io/images/peco-demo-matcher.gif)
 
 ## Selectable Layout
 
@@ -158,9 +160,13 @@ Changes how peco interprets incoming data. When this flag is set, you may insert
 
 Specifies the initial line position upon start up. E.g. If you want to start out with the second line selected, set it to "1" (because the index is 0 based)
 
-### --initial-filter `IgnoreCase|CaseSensitive|SmartCase|Regexp`
+### --fuzzy-filter `enabled|disabled`
 
-Specifies the initial filter to use upon start up. You should specify the name of the filter like `IgnoreCase`, `CaseSensitive`, `SmartCase` and `Regexp`. Default is `IgnoreCase`.
+Make the Fuzzy filter available. The command line option can override the value in the configuration file. Default is `disabled`.
+
+### --initial-filter `IgnoreCase|CaseSensitive|SmartCase|Regexp|Fuzzy`
+
+Specifies the initial filter to use upon start up. You should specify the name of the filter like `IgnoreCase`, `CaseSensitive`, `SmartCase`, `Regexp` and `Fuzzy` (if enabled). Default is `IgnoreCase`.
 
 ### --prompt
 
@@ -217,9 +223,13 @@ You can change the query line's prompt, which is `QUERY>` by default.
 
 *InitialMatcher* has been deprecated. Please use `InitialFilter` instead.
 
+### FuzzyFilter
+
+Set to `enabled` to make the Fuzzy filter available. Default is `disabled`.
+
 ### InitialFilter
 
-Specifies the filter name to start peco with. You should specify the name of the filter, such as `IgnoreCase`, `CaseSensitive`, `SmartCase` and `Regexp`
+Specifies the filter name to start peco with. You should specify the name of the filter, such as `IgnoreCase`, `CaseSensitive`, `SmartCase`, `Regexp` and `Fuzzy` (if [enabled](#FuzzyFilter)).
 
 ### StickySelection
 
@@ -473,7 +483,7 @@ For now, styles of following 5 items can be customized in `config.json`.
 
 This is an experimental feature. Please note that some details of this specification may change
 
-By default `peco` comes with `IgnoreCase`, `CaseSensitive`, `SmartCase` and `Regexp` filters, but since v0.1.3, it is possible to create your own custom filter.
+By default `peco` comes with `IgnoreCase`, `CaseSensitive`, `SmartCase`, `Regexp` and `Fuzzy` filters, but since v0.1.3, it is possible to create your own custom filter.
 
 The filter will be executed via  `Command.Run()` as an external process, and it will be passed the query values in the command line, and the original unaltered buffer is passed via `os.Stdin`. Your filter must perform the matching, and print out to `os.Stdout` matched lines. You filter MAY be called multiple times if the buffer
 given to peco is big enough. See `BufferThreshold` below.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The SmartCase filter uses case-*insensitive* matching when all of the queries ar
 
 The RegExp filter allows you to use any valid regular expression to match lines
 
-The Fuzzy filter allows you to find matches using partial patterns. For example, when searching for `ALongString`, you can enable the Fuzzy filter and search `ALS` to find it. The Fuzzy filter uses smart case search like the SmartCase filter. The Fuzzy filter is not enabled by default, but can be enabled using option `--fuzzy-filter`.
+The Fuzzy filter allows you to find matches using partial patterns. For example, when searching for `ALongString`, you can enable the Fuzzy filter and search `ALS` to find it. The Fuzzy filter uses smart case search like the SmartCase filter. The Fuzzy filter is not enabled by default, but can be enabled using the option `--fuzzy-filter`.
 
 ![Executed `ps aux | peco`, then typed `google`, which matches the Chrome.app under IgnoreCase filter type. When you change it to Regexp filter, this is no longer the case. But you can type `(?i)google` instead to toggle case-insensitive mode](http://peco.github.io/images/peco-demo-matcher.gif)
 

--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ func (c *Config) Init() error {
 	c.Style.Init()
 	c.Prompt = "QUERY>"
 	c.Layout = LayoutTypeTopDown
+	c.FuzzyFilter = OptionDisabled
 	return nil
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -47,6 +47,7 @@ func TestReadRC(t *testing.T) {
 		InitialMatcher: IgnoreCaseMatch,
 		Layout:         DefaultLayoutType,
 		Prompt:         "[peco]",
+		FuzzyFilter:    "disabled",
 		Style: StyleSet{
 			Matched: Style{
 				fg: termbox.ColorCyan | termbox.AttrBold,

--- a/filter.go
+++ b/filter.go
@@ -433,9 +433,8 @@ func NewFuzzyFilter() *RegexpFilter {
 		return []string{"i"}
 	})
 	rf.quotemeta = true
-	rf.name = "FuzzySearch"
+	rf.name = FuzzyFilter
 	rf.queryTrans = queryTransformerFunc(func(q string) string {
-		// Assume that all characters are runes
 		qr := []rune(q)
 		res := make([]rune, 5*len(qr))
 		i := 0

--- a/filter_test.go
+++ b/filter_test.go
@@ -12,6 +12,10 @@ func TestFuzzyFilter(t *testing.T) {
 		{"this is a test to test the fuzzy Filter", "tf", true},  // normal selection
 		{"this is a test to test the fuzzy Filter", "wp", false}, // incorrect selection
 		{"THIS IS A TEST TO TEST THE FUZZY FILTER", "tu", true},  // case insensitivity
+		{"this is a Test to test the fuzzy filter", "Tu", true},  // case sensitivity
+		{"this is a Test to test the fUzzy filter", "TU", true},  // case sensitivity
+		{"this is a test to test the fuzzy filter", "Tu", false}, // case sensitivity
+		{"this is a test to Test the fuzzy filter", "TU", false}, // case sensitivity
 		{"日本語は難しいです", "難", true},                                 // kanji
 		{"あ、日本語は難しいですよ", "あい", true},                             // hiragana
 		{"パソコンは遅いですネ", "ソネ", true},                               // katana

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,38 @@
+package peco
+
+import "testing"
+
+// TestFuzzyFilter tests a fuzzy filter against various inputs
+func TestFuzzyFilter(t *testing.T) {
+	testValues := []struct {
+		input    string
+		query    string
+		selected bool
+	}{
+		{"this is a test to test the fuzzy Filter", "tf", true},  // normal selection
+		{"this is a test to test the fuzzy Filter", "wp", false}, // incorrect selection
+		{"THIS IS A TEST TO TEST THE FUZZY FILTER", "tu", true},  // case insensitivity
+		{"日本語は難しいです", "難", true},                                 // kanji
+		{"あ、日本語は難しいですよ", "あい", true},                             // hiragana
+		{"パソコンは遅いですネ", "ソネ", true},                               // katana
+		{"🚴🏻 abcd efgh", "🚴🏻e", true},                            // unicode
+	}
+	filter := NewFuzzyFilter()
+	for i, v := range testValues {
+		filter.SetQuery(v.query)
+		l := NewRawLine(uint64(i), v.input, false)
+		res, err := filter.filter(l)
+		if v.selected && err != nil {
+			t.Log("Filtering failed.", "input", v.input, "query", v.query, "err", err)
+			t.Fail()
+		}
+		if v.selected && res == nil {
+			t.Log("The line should have been selected.", "input", v.input, "query", v.query)
+			t.Fail()
+		}
+		if !v.selected && res != nil {
+			t.Log("The line should not have been selected.", "input", v.input, "query", v.query)
+			t.Fail()
+		}
+	}
+}

--- a/filterutil.go
+++ b/filterutil.go
@@ -19,10 +19,18 @@ func (r regexpFlagFunc) flags(s string) []string {
 	return r(s)
 }
 
-func regexpFor(q string, flags []string, quotemeta bool) (*regexp.Regexp, error) {
+func (t queryTransformerFunc) transform(s string) string {
+	return t(s)
+}
+
+func regexpFor(q string, flags []string, quotemeta bool, queryTrans queryTransformer) (*regexp.Regexp, error) {
 	reTxt := q
 	if quotemeta {
 		reTxt = regexp.QuoteMeta(q)
+	}
+
+	if queryTrans != nil {
+		reTxt = queryTrans.transform(reTxt)
 	}
 
 	if flags != nil && len(flags) > 0 {
@@ -36,12 +44,12 @@ func regexpFor(q string, flags []string, quotemeta bool) (*regexp.Regexp, error)
 	return re, nil
 }
 
-func queryToRegexps(flags regexpFlags, quotemeta bool, query string) ([]*regexp.Regexp, error) {
+func queryToRegexps(flags regexpFlags, quotemeta bool, query string, queryTrans queryTransformer) ([]*regexp.Regexp, error) {
 	queries := strings.Split(strings.TrimSpace(query), " ")
 	regexps := make([]*regexp.Regexp, 0)
 
 	for _, q := range queries {
-		re, err := regexpFor(q, flags.flags(query), quotemeta)
+		re, err := regexpFor(q, flags.flags(query), quotemeta, queryTrans)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to compile regular expression '%s'", q)
 		}

--- a/interface.go
+++ b/interface.go
@@ -297,6 +297,16 @@ type regexpFlagList []string
 
 type regexpFlagFunc func(string) []string
 
+// queryTransformer is able to transform a query from one form to another.
+// This is used by the FuzzyFilter to transform the user query to a regular
+// expression.
+type queryTransformer interface {
+	transform(string) string
+}
+
+// type queryTransformerFunc implements queryTransformer.
+type queryTransformerFunc func(string) string
+
 // Filter is responsible for the actual "grep" part of peco
 type Filter struct {
 	state *Peco
@@ -324,7 +334,7 @@ type FilteredBuffer struct {
 }
 
 // Config holds all the data that can be configured in the
-// external configuran file
+// external configuration file
 type Config struct {
 	Action map[string][]string `json:"Action"`
 	// Keymap used to be directly responsible for dispatching
@@ -518,6 +528,7 @@ type RegexpFilter struct {
 	flags         regexpFlags
 	quotemeta     bool
 	query         string
+	queryTrans    queryTransformer
 	mutex         sync.Mutex
 	name          string
 	onEnd         func()

--- a/interface.go
+++ b/interface.go
@@ -46,6 +46,11 @@ const (
 	RegexpMatch        = "Regexp"
 )
 
+// Filter names, used in the config file
+const (
+	FuzzyFilter = "Fuzzy"
+)
+
 // lineIDGenerator defines an interface for things that generate
 // unique IDs for lines used within peco.
 type lineIDGenerator interface {
@@ -55,6 +60,11 @@ type lineIDGenerator interface {
 type idgen struct {
 	ch chan uint64
 }
+
+const (
+	OptionEnabled  = "enabled"
+	OptionDisabled = "disabled"
+)
 
 // Peco is the global object containing everything required to run peco.
 // It also contains the global state of the program.
@@ -74,6 +84,7 @@ type Peco struct {
 	enableSep               bool // Enable parsing on separators
 	filters                 FilterSet
 	idgen                   *idgen
+	enableFuzzy             bool
 	initialFilter           string
 	initialQuery            string   // populated if --query is specified
 	inputseq                Inputseq // current key sequence (just the names)
@@ -343,6 +354,7 @@ type Config struct {
 	Keymap              map[string]string `json:"Keymap"`
 	Matcher             string            `json:"Matcher"`        // Deprecated.
 	InitialMatcher      string            `json:"InitialMatcher"` // Use this instead of Matcher
+	FuzzyFilter         string            `json:"FuzzyFilter"`
 	InitialFilter       string            `json:"InitialFilter"`
 	Style               StyleSet          `json:"Style"`
 	Prompt              string            `json:"Prompt"`
@@ -475,6 +487,7 @@ type CLIOptions struct {
 	OptEnableNullSep  bool   `long:"null" description:"expect NUL (\\0) as separator for target/output"`
 	OptInitialIndex   int    `long:"initial-index" description:"position of the initial index of the selection (0 base)"`
 	OptInitialMatcher string `long:"initial-matcher" description:"specify the default matcher (deprecated)"`
+	OptFuzzyFilter    string `short:"z" long:"fuzzy-filter" description:"enable/disable the Fuzzy filter"`
 	OptInitialFilter  string `long:"initial-filter" description:"specify the default filter"`
 	OptPrompt         string `long:"prompt" description:"specify the prompt string"`
 	OptLayout         string `long:"layout" description:"layout to be used 'top-down' or 'bottom-up'. default is 'top-down'"`

--- a/peco.go
+++ b/peco.go
@@ -500,17 +500,17 @@ func (p *Peco) ApplyConfig(opts CLIOptions) error {
 	p.bufferSize = opts.OptBufferSize
 	p.selectOneAndExit = opts.OptSelect1
 	p.initialQuery = opts.OptQuery
-	// Option EnableFuzzy is a string to allow overriding the value on the command line
 	fuzzyFilter := opts.OptFuzzyFilter
 	if len(fuzzyFilter) <= 0 {
 		fuzzyFilter = p.config.FuzzyFilter
 	}
 	if len(fuzzyFilter) > 0 {
-		if fuzzyFilter == OptionEnabled {
+		switch fuzzyFilter {
+		case OptionEnabled:
 			p.enableFuzzy = true
-		} else if fuzzyFilter == OptionDisabled {
+		case OptionDisabled:
 			p.enableFuzzy = false
-		} else {
+		default:
 			return errors.Errorf("Unexpected value for FuzzyFilter option: %v (expected %v/%v)", fuzzyFilter, OptionEnabled, OptionDisabled)
 		}
 	}

--- a/peco.go
+++ b/peco.go
@@ -566,6 +566,7 @@ func (p *Peco) populateFilters() error {
 	p.filters.Add(NewCaseSensitiveFilter())
 	p.filters.Add(NewSmartCaseFilter())
 	p.filters.Add(NewRegexpFilter())
+	p.filters.Add(NewFuzzyFilter())
 
 	for name, c := range p.config.CustomFilter {
 		f := NewExternalCmdFilter(name, c.Cmd, c.Args, c.BufferThreshold, p.idgen, p.enableSep)

--- a/peco_test.go
+++ b/peco_test.go
@@ -197,6 +197,44 @@ func TestGHIssue331(t *testing.T) {
 	}
 }
 
+func TestConfigFuzzyFilter(t *testing.T) {
+	var opts CLIOptions
+	p := newPeco()
+
+	// Ensure that it's possible to enable the Fuzzy filter
+	opts.OptFuzzyFilter = "enabled"
+	if !assert.NoError(t, p.ApplyConfig(opts), "p.ApplyConfig should succeed") {
+		return
+	}
+	if !assert.Equal(t, true, p.enableFuzzy, "p.enableFuzzy should be equal to opts.OptEnableFuzzy") {
+		return
+	}
+	opts.OptFuzzyFilter = "abc"
+	if !assert.Error(t, p.ApplyConfig(opts), "p.ApplyConfig should not succeed") {
+		return
+	}
+}
+
+func TestConfigInitialFilterFuzzy(t *testing.T) {
+	var opts CLIOptions
+	p := newPeco()
+
+	// If Fuzzy is not enabled, initialFilter=Fuzzy should cause peco to fail
+	opts.OptFuzzyFilter = "disabled"
+	opts.OptInitialFilter = "Fuzzy"
+	if !assert.Error(t, p.ApplyConfig(opts), "p.ApplyConfig should not succeed") {
+		return
+	}
+	// If Fuzzy is enabled, it should be possible to set the initial filter to Fuzzy
+	opts.OptFuzzyFilter = "enabled"
+	if !assert.NoError(t, p.ApplyConfig(opts), "p.ApplyConfig should succeed") {
+		return
+	}
+	if !assert.Equal(t, true, p.enableFuzzy, "p.enableFuzzy should be equal to opts.OptEnableFuzzy") {
+		return
+	}
+}
+
 func TestApplyConfig(t *testing.T) {
 	// XXX We should add all the possible configurations that needs to be
 	// propagated to Peco from config


### PR DESCRIPTION
# Summary

Some users have a need to perform "fuzzy" searches in Peco. For example, when searching for "AVeryLongString", they would like to be able to type "AVLS" to filter results. Another use case is searching for paths "/var/log/this/is/a/very/long/path", where users could type the first letter of each directory.

The current version of peco supports this already via the Regexp filter, but it would be more handy to have this built in Peco instead of typing the regular expression each time.

# Implementation

The Fuzzy search is implemented as a new Filter. It re-uses the Regexp filter and automatically converts the user query to a regular expression, for example `AVLS` becomes `A(.*)V(.*)L(.*)S(.*)`. This is done using a new `queryTransformer` function in the `RegexpFilter` type , which is called before applying the user query to each line. It also uses the smart case feature.

# Configuration

The new filter is not enabled by default to avoid affecting the workflow of current users. However, it can be enabled if needed, using the `--fuzzy-filter=enabled` command line option, or the `FuzzyFilter` configuration. The command line option overrides the configuration if both are present. A clear error is returned if the initial filter is set to `Fuzzy` but the fuzzy filter is not enabled.

A more generic `ExtraFilters` configuration might be more useful if more filters are added later on, but it didn't seem necessary for now.

Thanks for this awesome tool and let me know if you have any comment on this change !