### PR TITLE
Fix --select-1

### DIFF
--- a/peco.go
+++ b/peco.go
@@ -219,6 +219,10 @@ func (p *Peco) Err() error {
 }
 
 func (p *Peco) Exit(err error) {
+	if pdebug.Enabled {
+		g := pdebug.Marker("Peco.Exit (err = %s)", err)
+		defer g.End()
+	}
 	p.err = err
 	if cf := p.cancelFunc; cf != nil {
 		cf()
@@ -348,7 +352,7 @@ func (p *Peco) Run(ctx context.Context) (err error) {
 			if b := p.CurrentLineBuffer(); b.Size() == 1 {
 				if l, err := b.LineAt(0); err == nil {
 					p.resultCh = make(chan line.Line)
-					p.Exit(nil)
+					p.Exit(errCollectResults{})
 					p.resultCh <- l
 					close(p.resultCh)
 				}

--- a/peco_test.go
+++ b/peco_test.go
@@ -291,6 +291,7 @@ func TestGHIssue363(t *testing.T) {
 	select {
 	case <-ctx.Done():
 		t.Errorf("timeout reached")
+		return
 	case err := <-resultCh:
 		if !assert.True(t, util.IsCollectResultsError(err), "isCollectResultsError") {
 			return


### PR DESCRIPTION
fixes #376.

So we had a regression for 363, but this time the problem was that the test itself was wrong.
The test should have been testing that `p.Run` returns an error (an ignorable one), but it wasn't.