### PR TITLE
Implement --selection-prefix

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,7 +6,12 @@ v0.4.8 - unreleased
   * A new command line option `--on-cancel` has been added. This allows you
     to determine if the user has canceled the query, which can be useful in
     a pipeline of commands.
-  * `OnCancel` does the equivalent of `--on-cancel` in the config file
+  * `OnCancel` does the equivalent of `--on-cancel` in the config file.
+  * A new command line option `--selection-prefix` has been added. This
+    allows you to use a string prefix instead of highlighting currently
+    selected lines.
+  * `SelectionPrefix` does the equivalent of `--selection-prefix` in the
+    config file.
 
 v0.4.7 - 17 Dec 2016
   Bugs/Fixes

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ See --layout.
 
 ## SelectionPrefix
 
-`SelectionPrefix` is equivalent to using `--select-prefix` in the command line.
+`SelectionPrefix` is equivalent to using `--selection-prefix` in the command line.
 
 ```
 {
@@ -677,7 +677,7 @@ Much code stolen from https://github.com/mattn/gof
 	* [--layout `top-down|bottom-up`](#--layout-top-downbottom-up)
 	* [--select-1](#--select-1)
 	* [--on-cancel `success|error`](#--on-cancel-successerror)
-        * [--select-prefix `string`](#--select-prefix-string)
+        * [--selection-prefix `string`](#--selection-prefix-string)
 * [Configuration File](#configuration-file)
 	* [Global](#global)
 		* [Prompt](#prompt)

--- a/README.md
+++ b/README.md
@@ -555,6 +555,16 @@ See --layout.
 }
 ```
 
+## SelectPrefix
+
+`SelectPrefix` is equivalent to using `--select-prefix` in the command line.
+
+```
+{
+  "SelectPrefix": ">"
+}
+```
+
 # FAQ
 
 ## Does peco work on (msys2|cygwin)?
@@ -667,6 +677,7 @@ Much code stolen from https://github.com/mattn/gof
 	* [--layout `top-down|bottom-up`](#--layout-top-downbottom-up)
 	* [--select-1](#--select-1)
 	* [--on-cancel `success|error`](#--on-cancel-successerror)
+        * [--select-prefix `string`](#--select-prefix-string)
 * [Configuration File](#configuration-file)
 	* [Global](#global)
 		* [Prompt](#prompt)
@@ -690,6 +701,7 @@ Much code stolen from https://github.com/mattn/gof
 	* [Layout](#layout)
 	* [SingleKeyJump](#singlekeyjump)
 	* [ExecuteCommand](#executecommand)
+	* [SelectPrefix](#selectprefix)
 * [FAQ](#faq)
 	* [Does peco work on (msys2|cygwin)?](#does-peco-work-on-msys2cygwin)
 	* [Non-latin fonts (e.g. Japanese) look weird on my Windows machine...?](#non-latin-fonts-eg-japanese-look-weird-on-my-windows-machine)

--- a/README.md
+++ b/README.md
@@ -555,13 +555,13 @@ See --layout.
 }
 ```
 
-## SelectPrefix
+## SelectionPrefix
 
-`SelectPrefix` is equivalent to using `--select-prefix` in the command line.
+`SelectionPrefix` is equivalent to using `--select-prefix` in the command line.
 
 ```
 {
-  "SelectPrefix": ">"
+  "SelectionPrefix": ">"
 }
 ```
 
@@ -701,7 +701,7 @@ Much code stolen from https://github.com/mattn/gof
 	* [Layout](#layout)
 	* [SingleKeyJump](#singlekeyjump)
 	* [ExecuteCommand](#executecommand)
-	* [SelectPrefix](#selectprefix)
+	* [SelectionPrefix](#selectionprefix)
 * [FAQ](#faq)
 	* [Does peco work on (msys2|cygwin)?](#does-peco-work-on-msys2cygwin)
 	* [Non-latin fonts (e.g. Japanese) look weird on my Windows machine...?](#non-latin-fonts-eg-japanese-look-weird-on-my-windows-machine)

--- a/interface.go
+++ b/interface.go
@@ -89,6 +89,7 @@ type Peco struct {
 	resultCh                chan line.Line
 	screen                  Screen
 	selection               *Selection
+	selectionPrefix         string
 	selectionRangeStart     RangeStart
 	selectOneAndExit        bool // True if --select-1 is enabled
 	singleKeyJumpMode       bool
@@ -416,6 +417,7 @@ type CLIOptions struct {
 	OptLayout         string `long:"layout" description:"layout to be used. 'top-down' or 'bottom-up'. default is 'top-down'"`
 	OptSelect1        bool   `long:"select-1" description:"select first item and immediately exit if the input contains only 1 item"`
 	OptOnCancel       string `long:"on-cancel" description:"specify action on user cancel. 'success' or 'error'.\ndefault is 'success'. This may change in future versions"`
+	OptSelectionPrefix string `long:"selection-prefix" description:"use a prefix instead of changing line color to indicate currently selected lines.\ndefault is to use colors. This option is experimental"`
 }
 
 type CLI struct {

--- a/interface.go
+++ b/interface.go
@@ -406,20 +406,20 @@ type State interface {
 }
 
 type CLIOptions struct {
-	OptHelp           bool   `short:"h" long:"help" description:"show this help message and exit"`
-	OptTTY            string `long:"tty" description:"path to the TTY (usually, the value of $TTY)"`
-	OptQuery          string `long:"query" description:"initial value for query"`
-	OptRcfile         string `long:"rcfile" description:"path to the settings file"`
-	OptVersion        bool   `long:"version" description:"print the version and exit"`
-	OptBufferSize     int    `long:"buffer-size" short:"b" description:"number of lines to keep in search buffer"`
-	OptEnableNullSep  bool   `long:"null" description:"expect NUL (\\0) as separator for target/output"`
-	OptInitialIndex   int    `long:"initial-index" description:"position of the initial index of the selection (0 base)"`
-	OptInitialMatcher string `long:"initial-matcher" description:"specify the default matcher (deprecated)"`
-	OptInitialFilter  string `long:"initial-filter" description:"specify the default filter"`
-	OptPrompt         string `long:"prompt" description:"specify the prompt string"`
-	OptLayout         string `long:"layout" description:"layout to be used. 'top-down' or 'bottom-up'. default is 'top-down'"`
-	OptSelect1        bool   `long:"select-1" description:"select first item and immediately exit if the input contains only 1 item"`
-	OptOnCancel       string `long:"on-cancel" description:"specify action on user cancel. 'success' or 'error'.\ndefault is 'success'. This may change in future versions"`
+	OptHelp            bool   `short:"h" long:"help" description:"show this help message and exit"`
+	OptTTY             string `long:"tty" description:"path to the TTY (usually, the value of $TTY)"`
+	OptQuery           string `long:"query" description:"initial value for query"`
+	OptRcfile          string `long:"rcfile" description:"path to the settings file"`
+	OptVersion         bool   `long:"version" description:"print the version and exit"`
+	OptBufferSize      int    `long:"buffer-size" short:"b" description:"number of lines to keep in search buffer"`
+	OptEnableNullSep   bool   `long:"null" description:"expect NUL (\\0) as separator for target/output"`
+	OptInitialIndex    int    `long:"initial-index" description:"position of the initial index of the selection (0 base)"`
+	OptInitialMatcher  string `long:"initial-matcher" description:"specify the default matcher (deprecated)"`
+	OptInitialFilter   string `long:"initial-filter" description:"specify the default filter"`
+	OptPrompt          string `long:"prompt" description:"specify the prompt string"`
+	OptLayout          string `long:"layout" description:"layout to be used. 'top-down' or 'bottom-up'. default is 'top-down'"`
+	OptSelect1         bool   `long:"select-1" description:"select first item and immediately exit if the input contains only 1 item"`
+	OptOnCancel        string `long:"on-cancel" description:"specify action on user cancel. 'success' or 'error'.\ndefault is 'success'. This may change in future versions"`
 	OptSelectionPrefix string `long:"selection-prefix" description:"use a prefix instead of changing line color to indicate currently selected lines.\ndefault is to use colors. This option is experimental"`
 }
 

--- a/interface.go
+++ b/interface.go
@@ -299,6 +299,9 @@ type Config struct {
 	// If this is true, then the prefix for single key jump mode
 	// is displayed by default.
 	SingleKeyJump SingleKeyJumpConfig `json:"SingleKeyJump"`
+
+	// Use this prefix to denote currently selected line
+	SelectionPrefix string `json:"SelectionPrefix"`
 }
 
 type SingleKeyJumpConfig struct {

--- a/peco.go
+++ b/peco.go
@@ -525,7 +525,11 @@ func (p *Peco) ApplyConfig(opts CLIOptions) error {
 		p.onCancel = errorKey
 	}
 	p.bufferSize = opts.OptBufferSize
-	p.selectionPrefix = opts.OptSelectionPrefix
+	if v := opts.OptSelectionPrefix; len(v) > 0 {
+		p.selectionPrefix = v
+	} else {
+		p.selectionPrefix = p.config.SelectionPrefix
+	}
 	p.selectOneAndExit = opts.OptSelect1
 	p.initialQuery = opts.OptQuery
 	p.initialFilter = opts.OptInitialFilter

--- a/peco.go
+++ b/peco.go
@@ -525,6 +525,7 @@ func (p *Peco) ApplyConfig(opts CLIOptions) error {
 		p.onCancel = errorKey
 	}
 	p.bufferSize = opts.OptBufferSize
+	p.selectionPrefix = opts.OptSelectionPrefix
 	p.selectOneAndExit = opts.OptSelect1
 	p.initialQuery = opts.OptQuery
 	p.initialFilter = opts.OptInitialFilter

--- a/peco_test.go
+++ b/peco_test.go
@@ -226,6 +226,7 @@ func TestApplyConfig(t *testing.T) {
 	opts.OptLayout = "bottom-up"
 	opts.OptSelect1 = true
 	opts.OptOnCancel = "error"
+	opts.OptSelectionPrefix = ">"
 
 	p := newPeco()
 	if !assert.NoError(t, p.ApplyConfig(opts), "p.ApplyConfig should succeed") {
@@ -265,6 +266,10 @@ func TestApplyConfig(t *testing.T) {
 	}
 
 	if !assert.Equal(t, opts.OptOnCancel, p.onCancel, "p.onCancel should be equal to opts.OptOnCancel") {
+		return
+	}
+
+	if !assert.Equal(t, opts.OptSelectionPrefix, p.selectionPrefix, "p.selectionPrefix should be equal to opts.OptSelectionPrefix") {
 		return
 	}
 }

--- a/source.go
+++ b/source.go
@@ -18,13 +18,13 @@ import (
 // call Setup()
 func NewSource(in io.Reader, idgen line.IDGenerator, capacity int, enableSep bool) *Source {
 	s := &Source{
-		in:            in, // Note that this may be closed, so do not rely on it
-		capacity:      capacity,
-		enableSep:     enableSep,
-		idgen:         idgen,
-		ready:         make(chan struct{}),
-		setupDone:     make(chan struct{}),
-		setupOnce:     sync.Once{},
+		in:         in, // Note that this may be closed, so do not rely on it
+		capacity:   capacity,
+		enableSep:  enableSep,
+		idgen:      idgen,
+		ready:      make(chan struct{}),
+		setupDone:  make(chan struct{}),
+		setupOnce:  sync.Once{},
 		ChanOutput: pipeline.ChanOutput(make(chan interface{})),
 	}
 	s.Reset()


### PR DESCRIPTION
Provides way to use prefix to denote currently selected line instead of highlighting the line

fixes #384