### PR TITLE
Resume reading from source when we are done reading

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,12 @@
 Changes
 =======
 
+v0.4.9 - unreleased
+  Bugs/Fixes
+  * An outstanding bug from v0.4.0 where specifying `--query` for a large
+    enough input would lose results in the first query execution has been
+    fixed (#389)
+
 v0.4.8 - 26 Feb 2017
   Features:
   * A new command line option `--on-cancel` has been added. This allows you


### PR DESCRIPTION
In order to serve the user filtered results as fast as possible,
we start reading from Source as soon as we have acquired a few lines
from STDIN or file.

So in case of #389, we started to process the source while we
are still reading from STDIN. But that means our buffer is not
quite ready with all of the input from STDIN.

Meanwhile, the filtering thinks it's done when we reach end of input
mark prematurely, and it never resumed reading. This is why we have
less lines than we should.

Now, in order to fix this, we need to process as much as we have, and
then come back to see if we have more. We do this by looping until
the setupDone channel is closed, and we have exhaused our buffer.

This fixes #389, but it also shows that the processing is a little
different when we run the filter for the first, and subsuquent
executions. Apparently the next execution takes a little bit longer
to *draw* (note: I have not checked if it's the filtering that's slow,
or that simply if the draw timings are off)