### PR TITLE
Tweak timing for when to initialize the screen and other components

### DIFF
--- a/screen.go
+++ b/screen.go
@@ -26,6 +26,10 @@ func NewTermbox() *Termbox {
 }
 
 func (t *Termbox) Close() error {
+	if pdebug.Enabled {
+		pdebug.Printf("Termbox: Close")
+	}
+	termbox.Interrupt()
 	termbox.Close()
 	return nil
 }
@@ -69,7 +73,6 @@ func (t *Termbox) PollEvent(ctx context.Context) chan termbox.Event {
 				if pdebug.Enabled {
 					pdebug.Printf("poll event suspended!")
 				}
-				termbox.Interrupt()
 				t.Close()
 			}
 		}


### PR DESCRIPTION
We should wait to initialize the screen until we have something
coming in from the source: otherwise multiple peograms chained via
pipes would compete for the same terminal resource, and things may
go southward.

But then there are components that rely on the screen being intialized,
so we let them wait as well.

fixes #397 