### PR TITLE
Limit ScrollRight until the right end of buffer

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/lestrrat/go-pdebug"
+	"github.com/mattn/go-runewidth"
 	"github.com/peco/peco/line"
 	"github.com/peco/peco/pipeline"
 	"github.com/pkg/errors"
@@ -50,6 +51,11 @@ func (flb FilteredBuffer) Size() int {
 	return len(flb.selection)
 }
 
+// Columns returns the max number of columns in the buffer
+func (flb FilteredBuffer) Columns() int {
+	return flb.src.Columns()
+}
+
 func NewMemoryBuffer() *MemoryBuffer {
 	mb := &MemoryBuffer{}
 	mb.Reset()
@@ -64,6 +70,23 @@ func (mb *MemoryBuffer) Size() int {
 
 func bufferSize(lines []line.Line) int {
 	return len(lines)
+}
+
+func (mb *MemoryBuffer) Columns() int {
+	mb.mutex.RLock()
+	defer mb.mutex.RUnlock()
+	return maxColumns(mb.lines)
+}
+
+func maxColumns(lines []line.Line) int {
+	maxCols := 0
+	for _, l := range lines {
+		cols := runewidth.StringWidth(l.DisplayString())
+		if cols > maxCols {
+			maxCols = cols
+		}
+	}
+	return maxCols
 }
 
 func (mb *MemoryBuffer) Reset() {

--- a/interface.go
+++ b/interface.go
@@ -345,6 +345,7 @@ type Caret struct {
 }
 
 type Location struct {
+	maxCol  int
 	col     int
 	lineno  int
 	maxPage int
@@ -421,6 +422,7 @@ type RangeStart struct {
 type Buffer interface {
 	LineAt(int) (line.Line, error)
 	Size() int
+	Columns() int
 }
 
 // MemoryBuffer is an implementation of Buffer

--- a/layout.go
+++ b/layout.go
@@ -640,6 +640,12 @@ func (l *BasicLayout) CalculatePage(state *Peco, perPage int) error {
 		loc.SetLineNumber(loc.Offset())
 	}
 
+	width, _ := l.screen.Size()
+	loc.SetMaxColumn(buf.Columns() - width)
+	if loc.MaxColumn() < 0 {
+		loc.SetMaxColumn(0)
+	}
+
 	return nil
 }
 
@@ -835,6 +841,9 @@ func horizontalScroll(state *Peco, l *BasicLayout, p PagingRequest) bool {
 	loc := state.Location()
 	if p.Type() == ToScrollRight {
 		loc.SetColumn(loc.Column() + width/2)
+		if loc.Column() > loc.MaxColumn() {
+			loc.SetColumn(loc.MaxColumn())
+		}
 	} else if loc.Column() > 0 {
 		loc.SetColumn(loc.Column() - width/2)
 		if loc.Column() < 0 {

--- a/page.go
+++ b/page.go
@@ -68,3 +68,11 @@ func (l Location) PageCrop() PageCrop {
 func (pf PageCrop) Crop(in Buffer) Buffer {
 	return NewFilteredBuffer(in, pf.currentPage, pf.perPage)
 }
+
+func (l *Location) SetMaxColumn(n int) {
+	l.maxCol = n
+}
+
+func (l Location) MaxColumn() int {
+	return l.maxCol
+}

--- a/source.go
+++ b/source.go
@@ -252,6 +252,12 @@ func (s *Source) Size() int {
 	return bufferSize(s.lines)
 }
 
+func (s *Source) Columns() int {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return maxColumns(s.lines)
+}
+
 func (s *Source) Append(l line.Line) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()


### PR DESCRIPTION
Related to https://github.com/peco/peco/pull/249

I don't want peco to unlimitedly scroll to right by peco.ScrollRight. I implemented the scroll limit to right direction.

## before
![before](https://cloud.githubusercontent.com/assets/3138447/23948995/c0b5f538-09c8-11e7-851b-cdb8cc87f601.gif)

## after
![after](https://cloud.githubusercontent.com/assets/3138447/23948999/c6cfc87c-09c8-11e7-8c34-4f17bef937e7.gif)
