### PR TITLE
Make Resume a blocking operation

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,8 +2,17 @@ Changes
 =======
 
 v0.5.1 - unreleased
+  Bugs/Fixes
+  * When --exec is used, and you come back from the external command,
+    you lost your selected location in the peco view. #410
   Backwards Incompatible Change:
   * --tty has been removed. it was not being used anyways.
+  Miscellaneous
+  * External commands specified in --exec now receive
+    PECO_FILENAME, PECO_LINE_COUNT, PECO_QUERY, and
+    PECO_MACHED_LINE_COUNT as environment variables
+  * Removed unused structs
+  * Fixed glide related Mkaefile actions
 
 v0.5.0 - 06 Mar 2017
   Backwards Incompatible Change:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ VERSION=$(patsubst "%",%,$(lastword $(shell grep 'const version' peco.go)))
 RELEASE_DIR=releases
 ARTIFACTS_DIR=$(RELEASE_DIR)/artifacts/$(VERSION)
 SRC_FILES = $(wildcard *.go cmd/peco/*.go internal/*/*.go)
-HAVE_GLIDE:=$(shell which glide >/dev/null 2>&1 && echo "yes")
+HAVE_GLIDE:=$(shell (test -e $(INTERNAL_BIN_DIR)/$(THIS_GOOS)/$(THIS_GOARCH)/glide || which glide >/dev/null 2>&1 ) && echo "yes")
 GITHUB_USERNAME=peco
 BUILD_TARGETS= \
 	build-linux-arm64 \

--- a/action.go
+++ b/action.go
@@ -356,7 +356,7 @@ func doFinish(ctx context.Context, state *Peco, _ termbox.Event) {
 
 	err = cmd.Run()
 	state.screen.Resume()
-	state.ExecQuery()
+	state.Hub().SendDraw(&DrawOptions{DisableCache: true})
 	if err != nil {
 		// bail out, or otherwise the user cannot know what happened
 		state.Exit(errors.Wrap(err, `failed to execute command`))

--- a/interface.go
+++ b/interface.go
@@ -162,8 +162,8 @@ type Screen interface {
 // Termbox just hands out the processing to the termbox library
 type Termbox struct {
 	mutex     sync.Mutex
-	resumeCh  chan (struct{})
-	suspendCh chan (struct{})
+	resumeCh  chan chan struct{}
+	suspendCh chan struct{}
 }
 
 // View handles the drawing/updating the screen


### PR DESCRIPTION
This is required because we need to make sure we know termbox
has been initialized before attempting to make another drawing
operation.

Notably, without proper termbox initialization, screen.Size() returns a
bogus value, and we miss the line location where we left off to execute
the external command specified by --exec

fixes #410