### PR TITLE
Only calculate the column size when necessary

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,8 @@ v0.5.1 - unreleased
   Backwards Incompatible Change:
   * --tty has been removed. it was not being used anyways.
   Miscellaneous
+  * When scrolling right, you could potentially keep on scrolling
+    infinitely. This has bee addressed by #409, #412
   * External commands specified in --exec now receive
     PECO_FILENAME, PECO_LINE_COUNT, PECO_QUERY, and
     PECO_MACHED_LINE_COUNT as environment variables

--- a/interface.go
+++ b/interface.go
@@ -268,6 +268,7 @@ type ActionFunc func(context.Context, *Peco, termbox.Event)
 // the source buffer (note: should be immutable) and a list of indices
 // into the source buffer
 type FilteredBuffer struct {
+	maxcols   int
 	src       Buffer
 	selection []int // maps from our index to src's index
 }
@@ -419,6 +420,7 @@ type RangeStart struct {
 // Buffer interface is used for containers for lines to be
 // processed by peco.
 type Buffer interface {
+	linesInRange(int, int) []line.Line
 	LineAt(int) (line.Line, error)
 	Size() int
 }

--- a/layout.go
+++ b/layout.go
@@ -364,6 +364,13 @@ func (l *ListArea) Draw(state *Peco, parent Layout, perPage int, options *DrawOp
 		loc.SetLineNumber(lbufsiz - 1)
 	}
 
+	// The max column size is calculated by buf. we check against where the
+	// loc variable thinks we should be scrolling to, and make sure that this
+	// falls in range with what we got
+	if max := buf.MaxColumn(); loc.Column() > max {
+		loc.SetColumn(max)
+	}
+
 	// previously drawn lines are cached. first, truncate the cache
 	// to current size of the drawable area
 	if ldc := int(len(l.displayCache)); ldc != perPage {

--- a/page.go
+++ b/page.go
@@ -65,6 +65,6 @@ func (l Location) PageCrop() PageCrop {
 
 // Crop returns a new Buffer whose contents are
 // bound within the given range
-func (pf PageCrop) Crop(in Buffer) Buffer {
+func (pf PageCrop) Crop(in Buffer) *FilteredBuffer {
 	return NewFilteredBuffer(in, pf.currentPage, pf.perPage)
 }

--- a/source.go
+++ b/source.go
@@ -240,6 +240,12 @@ func (s *Source) SetupDone() <-chan struct{} {
 	return s.setupDone
 }
 
+func (s *Source) linesInRange(start, end int) []line.Line {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.lines[start:end]
+}
+
 func (s *Source) LineAt(n int) (line.Line, error) {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()


### PR DESCRIPTION
This trims down the calculation required by #409 to only those lines
that will appear on screen, and still controls how far right we can
scroll to

closes #409