### PR TITLE
Reduce right scroll limit with a screen width

### DIFF
--- a/layout.go
+++ b/layout.go
@@ -367,7 +367,8 @@ func (l *ListArea) Draw(state *Peco, parent Layout, perPage int, options *DrawOp
 	// The max column size is calculated by buf. we check against where the
 	// loc variable thinks we should be scrolling to, and make sure that this
 	// falls in range with what we got
-	if max := buf.MaxColumn(); loc.Column() > max {
+	width, _ := state.screen.Size()
+	if max := maxOf(buf.MaxColumn()-width, 0); loc.Column() > max {
 		loc.SetColumn(max)
 	}
 
@@ -590,6 +591,13 @@ func (l *ListArea) Draw(state *Peco, parent Layout, perPage int, options *DrawOp
 	if pdebug.Enabled {
 		pdebug.Printf("ListArea.Draw: Written total of %d lines (%d cached)", written+cached, cached)
 	}
+}
+
+func maxOf(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 // NewDefaultLayout creates a new Layout in the default format (top-down)


### PR DESCRIPTION
With `loc.SetColumn(0)`, it can show `width` columns.
Thus if lines have `num` columns, we should limit scroll to `loc.SetColumn(num - width)`, not `loc.SetColumn(num)`.

Otherwise screen is blacked out when we unlimitedly do ScrollRight.

<hr>

Other than that, https://github.com/peco/peco/pull/412 works fine! Thank you 😄 