### PR TITLE
Makefile: remove unnecessary glide binary check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ VERSION=$(patsubst "%",%,$(lastword $(shell grep 'const version' peco.go)))
 RELEASE_DIR=releases
 ARTIFACTS_DIR=$(RELEASE_DIR)/artifacts/$(VERSION)
 SRC_FILES = $(wildcard *.go cmd/peco/*.go internal/*/*.go)
-HAVE_GLIDE:=$(shell (test -e $(INTERNAL_BIN_DIR)/$(THIS_GOOS)/$(THIS_GOARCH)/glide || which glide >/dev/null 2>&1 ) && echo "yes")
+HAVE_GLIDE:=$(shell test -e $(INTERNAL_BIN_DIR)/$(THIS_GOOS)/$(THIS_GOARCH)/glide && echo "yes")
 GITHUB_USERNAME=peco
 BUILD_TARGETS= \
 	build-linux-arm64 \


### PR DESCRIPTION
I don't know why does not works my environment, but if remove brace(`(`, `)`), it will work on both of exists `glide` binary in `$PATH`, and not exist `glide`.

The error log: (have `glide` binary on `$GOPATH/bin`)
```sh
$ make
Creating _internal_bin
Installing dependencies...
make: _internal_bin/darwin/amd64/glide: Command not found
make: *** [Makefile:53: installdeps] Error 127
```

My environment is here:

```sh
go version devel +193510f2f6 Fri Mar 17 22:35:29 2017 +0000 darwin/amd64
GOARCH="amd64"
GOBIN=""
GOEXE=""
GOHOSTARCH="amd64"
GOHOSTOS="darwin"
GOOS="darwin"
GOPATH="/Users/zchee/go"
GORACE=""
GOROOT="/usr/local/go"
GOTOOLDIR="/usr/local/go/pkg/tool/darwin_amd64"
GCCGO="gccgo"
CC="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
GOGCCFLAGS="-fPIC -m64 -pthread -fno-caret-diagnostics -Qunused-arguments -fmessage-length=0 -fdebug-prefix-map=/var/folders/kk/nlghjzs913d70lnngdp8bhsr0000gn/T/go-build402131269=/tmp/go-build -gno-record-gcc-switches -fno-common"
CXX="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"
CGO_ENABLED="1"
CGO_CFLAGS="-g -O2"
CGO_CPPFLAGS=""
CGO_CXXFLAGS="-g -O2"
CGO_FFLAGS="-g -O2"
CGO_LDFLAGS="-g -O2"
PKG_CONFIG="pkg-config"
GOROOT/bin/go version: go version devel +193510f2f6 Fri Mar 17 22:35:29 2017 +0000 darwin/amd64
GOROOT/bin/go tool compile -V: compile version devel +193510f2f6 Fri Mar 17 22:35:29 2017 +0000 X:framepointer
uname -v: Darwin Kernel Version 16.5.0: Fri Mar  3 16:45:33 PST 2017; root:xnu-3789.51.2~1/RELEASE_X86_64
ProductName:	Mac OS X
ProductVersion:	10.12.4
BuildVersion:	16E191a
```

```sh
SHELL=/usr/local/bin/zsh

$ zsh --version
zsh 5.3.1-dev-0 (x86_64-apple-darwin16.5.0)
```

```sh
GNU Make 4.2.1
Built for x86_64-apple-darwin16.0.0
```