### PR TITLE
Fix document to use new api "peco.RotateFilter"

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ Note: If in case below keymap seems wrong, check the source code in [keymap.go](
 |C-g|peco.SelectNone|
 |C-n|peco.SelectDown|
 |C-p|peco.SelectUp|
-|C-r|peco.RotateMatcher|
+|C-r|peco.RotateFilter|
 |C-t|peco.ToggleQuery|
 |C-Space|peco.ToggleSelectionAndSelectNext|
 |ArrowUp|peco.SelectUp|


### PR DESCRIPTION
fix to use new api "peco.RotateFilter" instead of deprecated "peco.RotateMatcher" in Default Keymap section.