### PR TITLE
Fixed typos in filter name

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Not only can you select multiple lines one by one, you can select a range of lin
 
 ## Select Filters
 
-Different types of filters are available. Default is case-insensitive filter, so lines with any case will match. You can toggle between IgnoreCase, CaseSensitive, SmartCase RegExp and Fuzzy filters. 
+Different types of filters are available. Default is case-insensitive filter, so lines with any case will match. You can toggle between IgnoreCase, CaseSensitive, SmartCase, Regexp and Fuzzy filters. 
 
 The SmartCase filter uses case-*insensitive* matching when all of the queries are lower case, and case-*sensitive* matching otherwise.
 
-The RegExp filter allows you to use any valid regular expression to match lines
+The Regexp filter allows you to use any valid regular expression to match lines
 
 The Fuzzy filter allows you to find matches using partial patterns. For example, when searching for `ALongString`, you can enable the Fuzzy filter and search `ALS` to find it. The Fuzzy filter uses smart case search like the SmartCase filter.
 


### PR DESCRIPTION
Using `-initial-filter RegExp` would result in "specified filter was not found".