### PR TITLE
Add scroll to top and bottom

### DIFF
--- a/action.go
+++ b/action.go
@@ -105,6 +105,9 @@ func init() {
 	ActionFunc(doScrollLeft).Register("ScrollLeft")
 	ActionFunc(doScrollRight).Register("ScrollRight")
 
+	ActionFunc(doScrollTop).Register("ScrollTop", termbox.KeyHome)
+	ActionFunc(doScrollBottom).Register("ScrollBottom", termbox.KeyEnd)
+
 	ActionFunc(doToggleSelection).Register("ToggleSelection")
 	ActionFunc(doToggleSelectionAndSelectNext).Register(
 		"ToggleSelectionAndSelectNext",
@@ -414,6 +417,14 @@ func doScrollLeft(ctx context.Context, state *Peco, e termbox.Event) {
 
 func doScrollRight(ctx context.Context, state *Peco, e termbox.Event) {
 	state.Hub().SendPaging(ToScrollRight)
+}
+
+func doScrollTop(ctx context.Context, state *Peco, e termbox.Event) {
+	state.Hub().SendPaging(ToScrollTop)
+}
+
+func doScrollBottom(ctx context.Context, state *Peco, e termbox.Event) {
+	state.Hub().SendPaging(ToScrollBottom)
 }
 
 func doToggleSelectionAndSelectNext(ctx context.Context, state *Peco, e termbox.Event) {

--- a/interface.go
+++ b/interface.go
@@ -29,6 +29,8 @@ const (
 	ToScrollLeft                              // ToScrollLeft scrolls screen to the left
 	ToScrollRight                             // ToScrollRight scrolls screen to the right
 	ToLineInPage                              // ToLineInPage jumps to a particular line on the page
+	ToScrollTop                               // ToScrollTop
+	ToScrollBottom                            // ToScrollBottom
 )
 
 const (

--- a/layout.go
+++ b/layout.go
@@ -758,6 +758,10 @@ func verticalScroll(state *Peco, l *BasicLayout, p PagingRequest) bool {
 			lineno -= lpp
 		case ToLineInPage:
 			lineno = loc.PerPage()*(loc.Page()-1) + p.(JumpToLineRequest).Line()
+		case ToScrollTop:
+			lineno = 0
+		case ToScrollBottom:
+			lineno = lcur - 1
 		}
 	} else {
 		switch p.Type() {


### PR DESCRIPTION
Just add scrolling to top and bottom (with default bindings Home and End).

The intended behavior of...
ScrollToTop is to scroll to the first item
ScrollToBottom is to scroll to the last item, (not the top of the last page, or anything like that. lmk if `lcur` is the wrong way to ask for that)