### PR TITLE
Update termbox-go revision

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -14,7 +14,7 @@ imports:
 - name: github.com/mattn/go-runewidth
   version: 737072b4e32b7a5018b4a7125da8d12de90e8045
 - name: github.com/nsf/termbox-go
-  version: abe82ce5fb7a42fbd6784a5ceb71aff977e09ed8
+  version: e2050e41c8847748ec5288741c0b19a8cb26d084
 - name: github.com/pkg/errors
   version: 248dadf4e9068a0b3e79f02ed0a610d935de5302
 - name: github.com/stretchr/testify


### PR DESCRIPTION
Hi, firstly thank you for your great job!
I'm big fan of this project.

I updated ncurses to version 6.1 at last week, then `peco` command has broken.
I searched and found the problem. (https://github.com/nsf/termbox-go/issues/185)
Then I update the dependency, I confirmed the problem was fixed.

# What is the peco version, OS, architecture? 

peco version: v0.5.2 (built with go1.9.4)
OS: Manjaro 17.1.6 Hakoila
Kernel: x86_64 Linux 4.14.24-1-MANJARO
terminal: rxvt-unicode (urxvt) v9.22
ncurses: 6.1-3

# Abstract

Update termbox-go version to HEAD of master.
It fixes a bug in termbox-go caused by ncurses 6.1.

## Bug

https://asciinema.org/a/mwkd1r4U3yMmq0mAq9u73hDOK

## Fixed

https://asciinema.org/a/AYEYQ1z4YU5SQ1cQfAYGMxKiT
