### PR TITLE
Add a few commands to use peco more like a pager

### DIFF
--- a/action.go
+++ b/action.go
@@ -127,6 +127,8 @@ func init() {
 	ActionFunc(doRefreshScreen).Register("RefreshScreen", termbox.KeyCtrlL)
 	ActionFunc(doToggleSingleKeyJump).Register("ToggleSingleKeyJump")
 
+	ActionFunc(doToggleViewArround).Register("ViewArround", termbox.KeyCtrlV)
+
 	ActionFunc(doKonamiCommand).RegisterKeySequence(
 		"KonamiCommand",
 		keyseq.KeyList{
@@ -769,6 +771,25 @@ func doToggleSingleKeyJump(ctx context.Context, state *Peco, e termbox.Event) {
 		defer g.End()
 	}
 	state.ToggleSingleKeyJumpMode()
+}
+
+func doToggleViewArround(ctx context.Context, state *Peco, e termbox.Event) {
+	if pdebug.Enabled {
+		g := pdebug.Marker("doToggleViewArround")
+		defer g.End()
+	}
+	q := state.Query()
+
+	if q.Len() > 0 {
+		l, err := state.CurrentLineBuffer().LineAt(state.Location().LineNumber())
+		if err != nil {
+			return
+		}
+		currentLine := l.ID()
+
+		doDeleteAll(ctx, state, e)
+		state.Hub().SendPaging(JumpToLineRequest(currentLine))
+	}
 }
 
 func doSingleKeyJump(ctx context.Context, state *Peco, e termbox.Event) {

--- a/input.go
+++ b/input.go
@@ -3,8 +3,8 @@ package peco
 import (
 	"time"
 
-	"github.com/nsf/termbox-go"
 	"context"
+	"github.com/nsf/termbox-go"
 )
 
 func NewInput(state *Peco, am ActionMap, src chan termbox.Event) *Input {

--- a/issues_test.go
+++ b/issues_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	termbox "github.com/nsf/termbox-go"
 	"github.com/stretchr/testify/assert"
-	"context"
 )
 
 func TestIssue212_SanityCheck(t *testing.T) {

--- a/keymap.go
+++ b/keymap.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 	"time"
 
+	"context"
 	"github.com/lestrrat/go-pdebug"
 	"github.com/nsf/termbox-go"
 	"github.com/peco/peco/internal/keyseq"
 	"github.com/pkg/errors"
-	"context"
 )
 
 // NewKeymap creates a new Keymap struct

--- a/query.go
+++ b/query.go
@@ -74,7 +74,7 @@ func (q *Query) Runes() <-chan rune {
 		defer q.mutex.Unlock()
 
 		for _, r := range q.query {
-			c<-r
+			c <- r
 		}
 	}()
 

--- a/source.go
+++ b/source.go
@@ -18,7 +18,7 @@ import (
 // call Setup()
 func NewSource(name string, in io.Reader, idgen line.IDGenerator, capacity int, enableSep bool) *Source {
 	s := &Source{
-		name: name,
+		name:       name,
 		in:         in, // Note that this may be closed, so do not rely on it
 		capacity:   capacity,
 		enableSep:  enableSep,

--- a/view.go
+++ b/view.go
@@ -3,8 +3,8 @@ package peco
 import (
 	"time"
 
-	"github.com/peco/peco/hub"
 	"context"
+	"github.com/peco/peco/hub"
 )
 
 type statusMsgReq interface {


### PR DESCRIPTION
Hello, thanks for peco, it is a great tool, the more I use it the more I find some interesting use cases !

This PR adds 3 commands to facilitate navigation:

* ViewArround
This reset the filter but leave the view at the current line. For instance you may open a log file with peco, find a specific line and use this to see the logs around. 


* GoToNextSelection
* GoToPreviousSelection

This allow to go to navigate to the previous/next selection. For instance, you may open a log file with peco, find some specific lines using the filter, select them all, reset the view and navigate with these actions.

The idea is to allow to use peco as a super pager.

Best,

PS: I am a golang beginner, comments are very welcome !