### PR TITLE
Clarify directory structure at build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ C:\> choco install peco
 
 ### Building peco yourself
 
-From the root of your cloned peco repository, run:
+From the root ($GOPATH/src/github.com/peco/peco/) of your cloned peco repository, run:
 
 ```
 glide install


### PR DESCRIPTION
I followed instruction in "Building peco yourself" (https://github.com/peco/peco#building-peco-yourself) and get "cannot find package" on "go build cmd/peco/peco.go".
When I make the correct directory structure, the error disappeared.
I think it is useful to add a note to the document.

reference: https://github.com/Masterminds/glide/issues/602
