### PR TITLE
Add installation instructions for debian and ubuntu based distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ If you're on OS X and want to use homebrew:
 brew install peco
 ```
 
+### Debian and Ubuntu based distributions
+
+There is an official Debian package that can be installed via APT:
+
+```
+apt install peco
+```
+
 ### Windows (Chocolatey NuGet Users)
 
 There's a third-party [peco package available](https://chocolatey.org/packages/peco) for Chocolatey NuGet.


### PR DESCRIPTION
As peco is available in the default Debian/Ubuntu repositories, I suggest to include the respective installation instructions here, so people do not think they have to build manually.