### PR TITLE
APT and Scarf installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,32 @@ Go to the [releases page](https://github.com/peco/peco/releases), find the versi
 
 _THIS IS THE RECOMMENDED WAY_ (except for OS X homebrew users)
 
-### Mac OS X / Homebrew
+### Mac OS X (Homebrew, Scarf)
 
 If you're on OS X and want to use homebrew:
 
 ```
 brew install peco
+```
+
+or with Scarf:
+
+```
+scarf install peco
+```
+
+### Debian / Ubuntu  (APT, Scarf)
+
+To install with apt:
+
+```
+apt install peco
+```
+
+or with Scarf:
+
+```
+scarf install peco
 ```
 
 ### Windows (Chocolatey NuGet Users)


### PR DESCRIPTION
This README change adds install instructions for `apt` as well as  `scarf` package managers (disclaimer, I am the author of Scarf). I uploaded the [Scarf package](https://scarf.sh/package/scarf/peco), and would be happy to transfer package ownership so you can see peco's usage statistics and use Scarf's tooling if you're interested in monetizing this package when it is used in a commercial setting. 