### PR TITLE
Fix GitHub spelling

### DIFF
--- a/Changes
+++ b/Changes
@@ -382,7 +382,7 @@ v0.1.8 - 25 Jun 2014
 
 v0.1.7 - 22 Jun 2014
   Bugs/Fixes:
-  * Moved repository to a Github organization: http://github.com/peco/peco
+  * Moved repository to a GitHub organization: http://github.com/peco/peco
   * Because of the above change, a lot of links, imports needed fixing.
   Features:
   * Automatically set GOMAXPROCS to NumCPU. If you would like to

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Simplistic interactive filtering tool
 
-*NOTE*: If you are viewing this on Github, this document refers to the state of `peco` in whatever current branch you are viewing, _not_ necessarily the state of a currently released version. Please make sure to checkout the [Changes](./Changes) file for features and changes.
+*NOTE*: If you are viewing this on GitHub, this document refers to the state of `peco` in whatever current branch you are viewing, _not_ necessarily the state of a currently released version. Please make sure to checkout the [Changes](./Changes) file for features and changes.
 
 This README is long and comprehensive. Use the [Table of Contents](#table-of-contents) to navigate to the section that interests you. It has been placed at the bottom of the README file because of its length.
 


### PR DESCRIPTION
Just a minor typo fix: `Github` -> `GitHub`.