### PR TITLE
updated termbox. solves issue with tmux-256color TERM definition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/jessevdk/go-flags v1.1.0
 	github.com/lestrrat-go/pdebug v0.0.0-20180220043849-39f9a71bcabe
 	github.com/mattn/go-runewidth v0.0.0-20161012013512-737072b4e32b
-	github.com/nsf/termbox-go v0.0.0-20180303152453-e2050e41c884
+	github.com/nsf/termbox-go v0.0.0-20180303152453-93860e161317
 	github.com/pkg/errors v0.0.0-20161029093637-248dadf4e906
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312


### PR DESCRIPTION
Just updated termbox version in order to solve my conflict with TERM=tmux-256color where an error is thrown.