### PR TITLE
Properly execute selectOneAndExit logic when an initial query is specified

### DIFF
--- a/action.go
+++ b/action.go
@@ -180,7 +180,7 @@ func doAcceptChar(ctx context.Context, state *Peco, e termbox.Event) {
 	h := state.Hub()
 	h.SendDrawPrompt() // Update prompt before running query
 
-	state.ExecQuery()
+	state.ExecQuery(nil)
 }
 
 func doRotateFilter(ctx context.Context, state *Peco, e termbox.Event) {
@@ -192,7 +192,7 @@ func doRotateFilter(ctx context.Context, state *Peco, e termbox.Event) {
 	filters := state.Filters()
 	filters.Rotate()
 
-	if state.ExecQuery() {
+	if state.ExecQuery(nil) {
 		return
 	}
 	state.Hub().SendDrawPrompt()
@@ -207,7 +207,7 @@ func doBackToInitialFilter(ctx context.Context, state *Peco, e termbox.Event) {
 	filters := state.Filters()
 	filters.Reset()
 
-	if state.ExecQuery() {
+	if state.ExecQuery(nil) {
 		return
 	}
 	state.Hub().SendDrawPrompt()
@@ -509,7 +509,7 @@ func doDeleteBackwardWord(ctx context.Context, state *Peco, _ termbox.Event) {
 		q.DeleteRange(0, start)
 		c.SetPos(0)
 	}
-	if state.ExecQuery() {
+	if state.ExecQuery(nil) {
 		return
 	}
 	state.Hub().SendDrawPrompt()
@@ -634,7 +634,7 @@ func doDeleteForwardWord(ctx context.Context, state *Peco, _ termbox.Event) {
 		}
 	}
 
-	if state.ExecQuery() {
+	if state.ExecQuery(nil) {
 		return
 	}
 	state.Hub().SendDrawPrompt()
@@ -662,7 +662,7 @@ func doKillBeginningOfLine(ctx context.Context, state *Peco, _ termbox.Event) {
 	q := state.Query()
 	q.DeleteRange(0, state.Caret().Pos())
 	state.Caret().SetPos(0)
-	if state.ExecQuery() {
+	if state.ExecQuery(nil) {
 		return
 	}
 	state.Hub().SendDrawPrompt()
@@ -675,7 +675,7 @@ func doKillEndOfLine(ctx context.Context, state *Peco, _ termbox.Event) {
 
 	q := state.Query()
 	q.DeleteRange(state.Caret().Pos(), q.Len())
-	if state.ExecQuery() {
+	if state.ExecQuery(nil) {
 		return
 	}
 	state.Hub().SendDrawPrompt()
@@ -683,7 +683,7 @@ func doKillEndOfLine(ctx context.Context, state *Peco, _ termbox.Event) {
 
 func doDeleteAll(ctx context.Context, state *Peco, _ termbox.Event) {
 	state.Query().Reset()
-	state.ExecQuery()
+	state.ExecQuery(nil)
 }
 
 func doDeleteForwardChar(ctx context.Context, state *Peco, _ termbox.Event) {
@@ -696,7 +696,7 @@ func doDeleteForwardChar(ctx context.Context, state *Peco, _ termbox.Event) {
 	pos := c.Pos()
 	q.DeleteRange(pos, pos+1)
 
-	if state.ExecQuery() {
+	if state.ExecQuery(nil) {
 		return
 	}
 	state.Hub().SendDrawPrompt()
@@ -735,7 +735,7 @@ func doDeleteBackwardChar(ctx context.Context, state *Peco, e termbox.Event) {
 	}
 	c.SetPos(pos - 1)
 
-	if state.ExecQuery() {
+	if state.ExecQuery(nil) {
 		return
 	}
 
@@ -759,7 +759,7 @@ func doToggleQuery(ctx context.Context, state *Peco, _ termbox.Event) {
 		q.SaveQuery()
 	}
 
-	if state.ExecQuery() {
+	if state.ExecQuery(nil) {
 		return
 	}
 	state.Hub().SendDrawPrompt()

--- a/input.go
+++ b/input.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"context"
+
+	"github.com/lestrrat-go/pdebug"
 	"github.com/nsf/termbox-go"
 )
 
@@ -31,6 +33,11 @@ func (i *Input) Loop(ctx context.Context, cancel func()) error {
 }
 
 func (i *Input) handleInputEvent(ctx context.Context, ev termbox.Event) error {
+	if pdebug.Enabled {
+		g := pdebug.Marker("event received from user: %#v", ev)
+		defer g.End()
+	}
+
 	switch ev.Type {
 	case termbox.EventError:
 		return nil

--- a/peco.go
+++ b/peco.go
@@ -406,6 +406,8 @@ func (p *Peco) Run(ctx context.Context) (err error) {
 			// if we only have one item
 			if p.selectOneAndExit {
 				p.ExecQuery(p.selectOneAndExitIfPossible)
+			} else {
+				p.ExecQuery(nil)
 			}
 		}()
 	}
@@ -723,7 +725,7 @@ func (p *Peco) ExecQuery(nextFunc func()) bool {
 	// Wait $delay millisecs before sending the query
 	// if a new input comes in, batch them up
 	if pdebug.Enabled {
-		pdebug.Printf("sending query with delay)")
+		pdebug.Printf("sending query (with delay)")
 	}
 	p.queryExecTimer = time.AfterFunc(delay, func() {
 		if pdebug.Enabled {

--- a/peco.go
+++ b/peco.go
@@ -293,6 +293,20 @@ func (p *Peco) Setup() (err error) {
 	return nil
 }
 
+func (p *Peco) selectOneAndExitIfPossible() {
+	// TODO: mutex
+	// If we have only one line, we just want to bail out
+	// printing that one line as the result
+	if b := p.CurrentLineBuffer(); b.Size() == 1 {
+		if l, err := b.LineAt(0); err == nil {
+			p.resultCh = make(chan line.Line)
+			p.Exit(errCollectResults{})
+			p.resultCh <- l
+			close(p.resultCh)
+		}
+	}
+}
+
 func (p *Peco) Run(ctx context.Context) (err error) {
 	if pdebug.Enabled {
 		g := pdebug.Marker("Peco.Run").BindError(&err)
@@ -371,16 +385,7 @@ func (p *Peco) Run(ctx context.Context) (err error) {
 			// a line, where as SetupDone waits until we're completely
 			// done reading the input
 			<-p.source.SetupDone()
-			// If we have only one line, we just want to bail out
-			// printing that one line as the result
-			if b := p.CurrentLineBuffer(); b.Size() == 1 {
-				if l, err := b.LineAt(0); err == nil {
-					p.resultCh = make(chan line.Line)
-					p.Exit(errCollectResults{})
-					p.resultCh <- l
-					close(p.resultCh)
-				}
-			}
+			p.selectOneAndExitIfPossible()
 		}()
 	}
 
@@ -396,7 +401,12 @@ func (p *Peco) Run(ctx context.Context) (err error) {
 	if p.Query().Len() > 0 {
 		go func() {
 			<-p.source.Ready()
-			p.ExecQuery()
+
+			// iff p.selectOneAndExit is true, we should check after exec query is run
+			// if we only have one item
+			if p.selectOneAndExit {
+				p.ExecQuery(p.selectOneAndExitIfPossible)
+			}
 		}()
 	}
 
@@ -645,11 +655,18 @@ func (p *Peco) ResetCurrentLineBuffer() {
 	p.SetCurrentLineBuffer(p.source)
 }
 
-func (p *Peco) ExecQuery() bool {
+// ExecQuery executes the query, taking in consideration things like the
+// exec-delay, and user's multiple successive inputs in a very short span
+//
+// if nextFunc is non-nil, then nextFunc is executed after the query is
+// executed
+func (p *Peco) ExecQuery(nextFunc func()) bool {
 	if pdebug.Enabled {
 		g := pdebug.Marker("Peco.ExecQuery")
 		defer g.End()
 	}
+
+	hub := p.Hub()
 
 	select {
 	case <-p.Ready():
@@ -668,7 +685,13 @@ func (p *Peco) ExecQuery() bool {
 			pdebug.Printf("empty query, reset buffer")
 		}
 		p.ResetCurrentLineBuffer()
-		p.Hub().SendDraw(&DrawOptions{DisableCache: true})
+
+		hub.Batch(func() {
+			hub.SendDraw(&DrawOptions{DisableCache: true})
+			if nextFunc != nil {
+				nextFunc()
+			}
+		}, false)
 		return true
 	}
 
@@ -678,7 +701,12 @@ func (p *Peco) ExecQuery() bool {
 			pdebug.Printf("sending query (immediate)")
 		}
 		// No delay, execute immediately
-		p.Hub().SendQuery(q.String())
+		hub.Batch(func() {
+			hub.SendQuery(q.String())
+			if nextFunc != nil {
+				nextFunc()
+			}
+		}, false)
 		return true
 	}
 
@@ -701,7 +729,12 @@ func (p *Peco) ExecQuery() bool {
 		if pdebug.Enabled {
 			pdebug.Printf("delayed query sent")
 		}
-		p.Hub().SendQuery(q.String())
+		hub.Batch(func() {
+			hub.SendQuery(q.String())
+			if nextFunc != nil {
+				nextFunc()
+			}
+		}, false)
 
 		p.queryExecMutex.Lock()
 		defer p.queryExecMutex.Unlock()

--- a/peco_test.go
+++ b/peco_test.go
@@ -12,6 +12,7 @@ import (
 
 	"context"
 
+	"github.com/lestrrat-go/pdebug"
 	"github.com/nsf/termbox-go"
 	"github.com/peco/peco/hub"
 	"github.com/peco/peco/internal/util"
@@ -359,7 +360,11 @@ func TestGHIssue367(t *testing.T) {
 
 		l := len(src[0])
 		copy(p, src[0])
+		p = p[:l]
 		src = src[1:]
+		if pdebug.Enabled {
+			pdebug.Printf("reader func returning %#v", string(p))
+		}
 		return l, nil
 	})
 	buf := bytes.Buffer{}
@@ -371,9 +376,13 @@ func TestGHIssue367(t *testing.T) {
 		p.Run(ctx)
 	}()
 
-	p.Query().Set("bar")
-
 	select {
+	case <-time.After(100 * time.Millisecond):
+		p.screen.SendEvent(termbox.Event{Ch: 'b'})
+	case <-time.After(200 * time.Millisecond):
+		p.screen.SendEvent(termbox.Event{Ch: 'a'})
+	case <-time.After(300 * time.Millisecond):
+		p.screen.SendEvent(termbox.Event{Ch: 'r'})
 	case <-time.After(900 * time.Millisecond):
 		p.screen.SendEvent(termbox.Event{Key: termbox.KeyEnter})
 	}


### PR DESCRIPTION
Should fix #490