### PR TITLE
Support 256color

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,6 +716,7 @@ Implement all(?) of the original percol options
 * Yousuke Ushiki
 * Linda\_pp
 * Tomohiro Nishimura (Sixeight)
+* Naruki Tanabe (narugit)
 
 # Notes
 

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Below are configuration sections that you may specify in your config file:
 * [CustomFilter](#customfilter)
 * [Prompt](#prompt)
 * [InitialMatcher](#initialmatcher)
+* [Use256Color](#use256color)
 
 ## Global
 
@@ -538,6 +539,7 @@ For now, styles of following 5 items can be customized in `config.json`.
 - `"magenta"` for `termbox.ColorMagenta`
 - `"cyan"` for `termbox.ColorCyan`
 - `"white"` for `termbox.ColorWhite`
+- `"0"`-`"255"` for 256color ([Use256Color](#use256color) must be enabled)
 
 ### Background Colors
 
@@ -549,6 +551,7 @@ For now, styles of following 5 items can be customized in `config.json`.
 - `"on_magenta"` for `termbox.ColorMagenta`
 - `"on_cyan"` for `termbox.ColorCyan`
 - `"on_white"` for `termbox.ColorWhite`
+- `"on_0"`-`"on_255"` for 256color ([Use256Color](#use256color) must be enabled)
 
 ### Attributes
 
@@ -619,6 +622,18 @@ See --layout.
 ```
 {
   "SelectionPrefix": ">"
+}
+```
+
+## Use256Color
+
+Boolean value that determines whether or not to use 256color. The default is `false`.
+
+Note: This has no effect on Windows because Windows console does not support extra color modes.
+
+```json
+{
+    "Use256Color": true
 }
 ```
 

--- a/config.go
+++ b/config.go
@@ -22,6 +22,7 @@ func (c *Config) Init() error {
 	c.Style.Init()
 	c.Prompt = "QUERY>"
 	c.Layout = LayoutTypeTopDown
+	c.Use256Color = false
 	return nil
 }
 

--- a/config.go
+++ b/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"strconv"
 
 	"github.com/nsf/termbox-go"
 	"github.com/peco/peco/filter"
@@ -133,11 +134,21 @@ func stringsToStyle(style *Style, raw []string) error {
 		fg, ok := stringToFg[s]
 		if ok {
 			style.fg = fg
+		} else {
+			if fg, err := strconv.ParseUint(s, 10, 8); err == nil {
+				style.fg = termbox.Attribute(fg+1)
+			}
 		}
 
 		bg, ok := stringToBg[s]
 		if ok {
 			style.bg = bg
+		} else {
+			if strings.HasPrefix(s, "on_") {
+				if bg, err := strconv.ParseUint(s[3:], 10, 8); err == nil {
+					style.bg = termbox.Attribute(bg+1)
+				}
+			}
 		}
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -99,6 +99,10 @@ func TestStringsToStyle(t *testing.T) {
 			strings: []string{"on_bold", "on_magenta", "green"},
 			style:   &Style{fg: termbox.ColorGreen, bg: termbox.ColorMagenta | termbox.AttrBold},
 		},
+		stringsToStyleTest{
+			strings: []string{"underline", "on_240", "214"},
+			style:   &Style{fg: (214+1) | termbox.AttrUnderline, bg: 240+1},
+		},
 	}
 
 	t.Logf("Checking strings -> color mapping...")

--- a/interface.go
+++ b/interface.go
@@ -151,10 +151,10 @@ type Selection struct {
 // Screen hides termbox from the consuming code so that
 // it can be swapped out for testing
 type Screen interface {
-	Init() error
+	Init(*Config) error
 	Close() error
 	Flush() error
-	PollEvent(context.Context) chan termbox.Event
+	PollEvent(context.Context, *Config) chan termbox.Event
 	Print(PrintArgs) int
 	Resume()
 	SetCell(int, int, rune, termbox.Attribute, termbox.Attribute)

--- a/interface.go
+++ b/interface.go
@@ -103,6 +103,7 @@ type Peco struct {
 	singleKeyJumpShowPrefix bool
 	skipReadConfig          bool
 	styles                  StyleSet
+	use256Color             bool
 
 	// Source is where we buffer input. It gets reused when a new query is
 	// executed.
@@ -291,6 +292,7 @@ type Config struct {
 	Style               StyleSet          `json:"Style"`
 	Prompt              string            `json:"Prompt"`
 	Layout              string            `json:"Layout"`
+	Use256Color         bool              `json:"Use256Color"`
 	OnCancel            string            `json:"OnCancel"`
 	CustomMatcher       map[string][]string
 	CustomFilter        map[string]CustomFilterConfig

--- a/peco.go
+++ b/peco.go
@@ -364,8 +364,8 @@ func (p *Peco) Run(ctx context.Context) (err error) {
 		// screen.Init must be called within Run() because we
 		// want to make sure to call screen.Close() after getting
 		// out of Run()
-		p.screen.Init()
-		go NewInput(p, p.Keymap(), p.screen.PollEvent(ctx)).Loop(ctx, cancel)
+		p.screen.Init(&p.config)
+		go NewInput(p, p.Keymap(), p.screen.PollEvent(ctx, &p.config)).Loop(ctx, cancel)
 		go NewView(p).Loop(ctx, cancel)
 		go NewFilter(p).Loop(ctx, cancel)
 	}()

--- a/peco.go
+++ b/peco.go
@@ -137,6 +137,10 @@ func (p *Peco) Styles() *StyleSet {
 	return &p.styles
 }
 
+func (p *Peco) Use256Color() bool {
+	return p.use256Color
+}
+
 func (p *Peco) Prompt() string {
 	return p.prompt
 }
@@ -541,6 +545,8 @@ func (p *Peco) ApplyConfig(opts CLIOptions) error {
 	} else if v := p.config.Prompt; len(v) > 0 {
 		p.prompt = v
 	}
+
+	p.use256Color = p.config.Use256Color
 
 	p.onCancel = successKey
 	if opts.OptOnCancel == errorKey || p.config.OnCancel == errorKey {

--- a/peco_test.go
+++ b/peco_test.go
@@ -105,7 +105,7 @@ func NewDummyScreen() *dummyScreen {
 func (d dummyScreen) SetCursor(_, _ int) {
 }
 
-func (d dummyScreen) Init() error {
+func (d dummyScreen) Init(cfg *Config) error {
 	return nil
 }
 
@@ -135,7 +135,7 @@ func (d dummyScreen) Flush() error {
 	d.record("Flush", interceptorArgs{})
 	return nil
 }
-func (d dummyScreen) PollEvent(ctx context.Context) chan termbox.Event {
+func (d dummyScreen) PollEvent(ctx context.Context, cfg *Config) chan termbox.Event {
 	return d.pollCh
 }
 func (d dummyScreen) Size() (int, int) {

--- a/screen.go
+++ b/screen.go
@@ -10,12 +10,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (t *Termbox) Init() error {
+func (t *Termbox) Init(cfg *Config) error {
 	if err := termbox.Init(); err != nil {
 		return errors.Wrap(err, "failed to initialized termbox")
 	}
 
-	return t.PostInit()
+	return t.PostInit(cfg)
 }
 
 func NewTermbox() *Termbox {
@@ -55,7 +55,7 @@ func (t *Termbox) Flush() error {
 // PollEvent returns a channel that you can listen to for
 // termbox's events. The actual polling is done in a
 // separate gouroutine
-func (t *Termbox) PollEvent(ctx context.Context) chan termbox.Event {
+func (t *Termbox) PollEvent(ctx context.Context, cfg *Config) chan termbox.Event {
 	// XXX termbox.PollEvent() can get stuck on unexpected signal
 	// handling cases. We still would like to wait until the user
 	// (termbox) has some event for us to process, but we don't
@@ -97,7 +97,7 @@ func (t *Termbox) PollEvent(ctx context.Context) chan termbox.Event {
 			case <-ctx.Done():
 				return
 			case replyCh := <-t.resumeCh:
-				t.Init()
+				t.Init(cfg)
 				close(replyCh)
 			}
 		}

--- a/screen_posix.go
+++ b/screen_posix.go
@@ -2,6 +2,14 @@
 
 package peco
 
-func (t *Termbox) PostInit() error {
+import "github.com/nsf/termbox-go"
+
+func (t *Termbox) PostInit(cfg *Config) error {
+	// This has no effect on Windows,
+	// because termbox.SetOutputMode always sets termbox.OutputNormal on Windows.
+	if cfg.Use256Color {
+		termbox.SetOutputMode(termbox.Output256)
+	}
+
 	return nil
 }

--- a/screen_windows.go
+++ b/screen_windows.go
@@ -2,7 +2,7 @@ package peco
 
 import "github.com/nsf/termbox-go"
 
-func (t *Termbox) PostInit() error {
+func (t *Termbox) PostInit(cfg *Config) error {
 	// Windows handle Esc/Alt self
 	termbox.SetInputMode(termbox.InputEsc | termbox.InputAlt)
 


### PR DESCRIPTION
Derived from #234 

### Test Result
<details>
<summary>test result</summary>

```
Downloading dependencies...
Running tests...
=== RUN   TestActionFunc
--- PASS: TestActionFunc (0.00s)
=== RUN   TestActionNames
--- PASS: TestActionNames (0.00s)
=== RUN   TestDoDeleteForwardChar
--- PASS: TestDoDeleteForwardChar (0.00s)
=== RUN   TestDoDeleteForwardWord
--- PASS: TestDoDeleteForwardWord (0.00s)
=== RUN   TestDoDeleteBackwardChar
--- PASS: TestDoDeleteBackwardChar (0.00s)
=== RUN   TestDoDeleteBackwardWord
--- PASS: TestDoDeleteBackwardWord (0.00s)
=== RUN   TestDoAcceptChar
--- PASS: TestDoAcceptChar (1.00s)
=== RUN   TestRotateFilter
--- PASS: TestRotateFilter (2.51s)
=== RUN   TestBeginningOfLineAndEndOfLine
--- PASS: TestBeginningOfLineAndEndOfLine (2.00s)
=== RUN   TestBackToInitialFilter
--- PASS: TestBackToInitialFilter (2.01s)
=== RUN   TestReadRC
--- PASS: TestReadRC (0.00s)
=== RUN   TestStringsToStyle
    TestStringsToStyle: config_test.go:108: Checking strings -> color mapping...
    TestStringsToStyle: config_test.go:111:     checking [on_default default]...
    TestStringsToStyle: config_test.go:111:     checking [bold on_blue yellow]...
    TestStringsToStyle: config_test.go:111:     checking [underline on_cyan black]...
    TestStringsToStyle: config_test.go:111:     checking [reverse on_red white]...
    TestStringsToStyle: config_test.go:111:     checking [on_bold on_magenta green]...
    TestStringsToStyle: config_test.go:111:     checking [underline on_240 214]...
--- PASS: TestStringsToStyle (0.00s)
=== RUN   TestLocateRcfile
    TestLocateRcfile: config_test.go:142: looking for file in /var/folders/sp/r27h557x4sqfw_4zvhgn43g00000gn/T/peco-418147212/peco
    TestLocateRcfile: config_test.go:142: looking for file in /var/folders/sp/r27h557x4sqfw_4zvhgn43g00000gn/T/peco-418147212/1/peco
    TestLocateRcfile: config_test.go:142: looking for file in /var/folders/sp/r27h557x4sqfw_4zvhgn43g00000gn/T/peco-418147212/2/peco
    TestLocateRcfile: config_test.go:142: looking for file in /var/folders/sp/r27h557x4sqfw_4zvhgn43g00000gn/T/peco-418147212/3/peco
    TestLocateRcfile: config_test.go:142: looking for file in /var/folders/sp/r27h557x4sqfw_4zvhgn43g00000gn/T/peco-418147212/.peco
    TestLocateRcfile: config_test.go:142: looking for file in /var/folders/sp/r27h557x4sqfw_4zvhgn43g00000gn/T/peco-418147212/.config/peco
    TestLocateRcfile: config_test.go:142: looking for file in /var/folders/sp/r27h557x4sqfw_4zvhgn43g00000gn/T/peco-418147212/1/peco
    TestLocateRcfile: config_test.go:142: looking for file in /var/folders/sp/r27h557x4sqfw_4zvhgn43g00000gn/T/peco-418147212/2/peco
    TestLocateRcfile: config_test.go:142: looking for file in /var/folders/sp/r27h557x4sqfw_4zvhgn43g00000gn/T/peco-418147212/3/peco
    TestLocateRcfile: config_test.go:142: looking for file in /var/folders/sp/r27h557x4sqfw_4zvhgn43g00000gn/T/peco-418147212/.peco
--- PASS: TestLocateRcfile (0.00s)
=== RUN   TestIssue212_SanityCheck
--- PASS: TestIssue212_SanityCheck (0.00s)
=== RUN   TestIssue345
--- PASS: TestIssue345 (1.01s)
=== RUN   TestLayoutType
--- PASS: TestLayoutType (0.00s)
=== RUN   TestPrintScreen
    TestPrintScreen: layout_test.go:38: Checking printScreen(0, 0, Hello, World!, false)
    TestPrintScreen: layout_test.go:38: Checking printScreen(0, 0, 日本語, false)
    TestPrintScreen: layout_test.go:38: Checking printScreen(0, 0, Hello, World!, true)
    TestPrintScreen: layout_test.go:38: Checking printScreen(0, 0, 日本語, true)
--- PASS: TestPrintScreen (0.00s)
=== RUN   TestStatusBar
--- PASS: TestStatusBar (0.00s)
=== RUN   TestMergeAttribute
--- PASS: TestMergeAttribute (0.00s)
=== RUN   TestIDGen
--- PASS: TestIDGen (1.27s)
=== RUN   TestPeco
--- PASS: TestPeco (1.00s)
=== RUN   TestPecoHelp
--- PASS: TestPecoHelp (0.00s)
=== RUN   TestGHIssue331
--- PASS: TestGHIssue331 (1.00s)
=== RUN   TestConfigFuzzyFilter
--- PASS: TestConfigFuzzyFilter (0.00s)
=== RUN   TestApplyConfig
--- PASS: TestApplyConfig (0.00s)
=== RUN   TestGHIssue363
--- PASS: TestGHIssue363 (0.00s)
=== RUN   TestGHIssue367
--- PASS: TestGHIssue367 (5.00s)
=== RUN   TestPrintQuery
=== RUN   TestPrintQuery/Match_and_print_query
=== RUN   TestPrintQuery/No_match_and_print_query
--- PASS: TestPrintQuery (0.10s)
    --- PASS: TestPrintQuery/Match_and_print_query (0.00s)
    --- PASS: TestPrintQuery/No_match_and_print_query (0.10s)
=== RUN   TestSelection
--- PASS: TestSelection (0.00s)
=== RUN   TestSource
--- PASS: TestSource (3.01s)
PASS
ok  	github.com/peco/peco	20.030s
?   	github.com/peco/peco/cmd/peco	[no test files]
=== RUN   TestFuzzy
=== RUN   TestFuzzy/"this_is_a_test_to_test_the_fuzzy_Filter"_against_"tf",_expect_"true"
    TestFuzzy/"this_is_a_test_to_test_the_fuzzy_Filter"_against_"tf",_expect_"true": filter_test.go:64: [][]int{[]int{0, 1}, []int{27, 28}}
=== RUN   TestFuzzy/"this_is_a_test_to_test_the_fuzzy_Filter"_against_"wp",_expect_"false"
=== RUN   TestFuzzy/"THIS_IS_A_TEST_TO_TEST_THE_FUZZY_FILTER"_against_"tu",_expect_"true"
    TestFuzzy/"THIS_IS_A_TEST_TO_TEST_THE_FUZZY_FILTER"_against_"tu",_expect_"true": filter_test.go:64: [][]int{[]int{0, 1}, []int{28, 29}}
=== RUN   TestFuzzy/"this_is_a_Test_to_test_the_fuzzy_filter"_against_"Tu",_expect_"true"
    TestFuzzy/"this_is_a_Test_to_test_the_fuzzy_filter"_against_"Tu",_expect_"true": filter_test.go:64: [][]int{[]int{10, 11}, []int{28, 29}}
=== RUN   TestFuzzy/"this_is_a_Test_to_test_the_fUzzy_filter"_against_"TU",_expect_"true"
    TestFuzzy/"this_is_a_Test_to_test_the_fUzzy_filter"_against_"TU",_expect_"true": filter_test.go:64: [][]int{[]int{10, 11}, []int{28, 29}}
=== RUN   TestFuzzy/"this_is_a_test_to_test_the_fuzzy_filter"_against_"Tu",_expect_"false"
=== RUN   TestFuzzy/"this_is_a_test_to_Test_the_fuzzy_filter"_against_"TU",_expect_"false"
=== RUN   TestFuzzy/"日本語は難しいです"_against_"難",_expect_"true"
    TestFuzzy/"日本語は難しいです"_against_"難",_expect_"true": filter_test.go:64: [][]int{[]int{12, 15}}
=== RUN   TestFuzzy/"あ、日本語は難しいですよ"_against_"あい",_expect_"true"
    TestFuzzy/"あ、日本語は難しいですよ"_against_"あい",_expect_"true": filter_test.go:64: [][]int{[]int{0, 3}, []int{24, 27}}
=== RUN   TestFuzzy/"パソコンは遅いですネ"_against_"ソネ",_expect_"true"
    TestFuzzy/"パソコンは遅いですネ"_against_"ソネ",_expect_"true": filter_test.go:64: [][]int{[]int{3, 6}, []int{27, 30}}
=== RUN   TestFuzzy/"🚴🏻_abcd_efgh"_against_"🚴🏻e",_expect_"true"
    TestFuzzy/"🚴🏻_abcd_efgh"_against_"🚴🏻e",_expect_"true": filter_test.go:64: [][]int{[]int{0, 4}, []int{4, 8}, []int{14, 15}}
=== RUN   TestFuzzy/"This_is_a_test_to_Test_the_fuzzy_filteR"_against_"TTR",_expect_"true"
    TestFuzzy/"This_is_a_test_to_Test_the_fuzzy_filteR"_against_"TTR",_expect_"true": filter_test.go:64: [][]int{[]int{0, 1}, []int{18, 19}, []int{38, 39}}
--- PASS: TestFuzzy (30.01s)
    --- PASS: TestFuzzy/"this_is_a_test_to_test_the_fuzzy_Filter"_against_"tf",_expect_"true" (0.00s)
    --- PASS: TestFuzzy/"this_is_a_test_to_test_the_fuzzy_Filter"_against_"wp",_expect_"false" (10.00s)
    --- PASS: TestFuzzy/"THIS_IS_A_TEST_TO_TEST_THE_FUZZY_FILTER"_against_"tu",_expect_"true" (0.00s)
    --- PASS: TestFuzzy/"this_is_a_Test_to_test_the_fuzzy_filter"_against_"Tu",_expect_"true" (0.00s)
    --- PASS: TestFuzzy/"this_is_a_Test_to_test_the_fUzzy_filter"_against_"TU",_expect_"true" (0.00s)
    --- PASS: TestFuzzy/"this_is_a_test_to_test_the_fuzzy_filter"_against_"Tu",_expect_"false" (10.01s)
    --- PASS: TestFuzzy/"this_is_a_test_to_Test_the_fuzzy_filter"_against_"TU",_expect_"false" (10.00s)
    --- PASS: TestFuzzy/"日本語は難しいです"_against_"難",_expect_"true" (0.00s)
    --- PASS: TestFuzzy/"あ、日本語は難しいですよ"_against_"あい",_expect_"true" (0.00s)
    --- PASS: TestFuzzy/"パソコンは遅いですネ"_against_"ソネ",_expect_"true" (0.00s)
    --- PASS: TestFuzzy/"🚴🏻_abcd_efgh"_against_"🚴🏻e",_expect_"true" (0.00s)
    --- PASS: TestFuzzy/"This_is_a_test_to_Test_the_fuzzy_filteR"_against_"TTR",_expect_"true" (0.00s)
PASS
ok  	github.com/peco/peco/filter	(cached)
=== RUN   TestHub
    TestHub: hub_test.go:83: Checkin if query was fired before draw
    TestHub: hub_test.go:83: Checkin if draw was fired before status
    TestHub: hub_test.go:83: Checkin if status was fired before paging
--- PASS: TestHub (0.41s)
PASS
ok  	github.com/peco/peco/hub	(cached)
?   	github.com/peco/peco/internal/buffer	[no test files]
=== RUN   TestTree
--- PASS: TestTree (0.00s)
=== RUN   TestKeymapStrToKeyValue
    TestKeymapStrToKeyValue: keys_test.go:85: Checking key name -> actual key value mapping...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking F1...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking F2...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-t...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-u...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-5...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking F6...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-j...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-l...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking F11...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-c...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-_...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking ArrowLeft...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-q...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-4...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking Delete...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking BS...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-Space...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-v...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-\...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-s...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-3...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-]...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking ArrowUp...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking BS2...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-g...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-m...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-w...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking F4...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking F9...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking F10...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking Pgdn...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking ArrowDown...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-e...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-y...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking Insert...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking Tab...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking Esc...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-2...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-f...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-h...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-r...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-6...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking F3...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking MouseMiddle...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-k...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-[...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking F12...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking MouseLeft...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking Space...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-d...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-o...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-p...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking F5...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking MouseRight...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-~...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-i...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking F7...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking End...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking Pgup...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-/...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-8...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-a...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-n...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-7...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking F8...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking Home...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-z...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking ArrowRight...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking Enter...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-b...
    TestKeymapStrToKeyValue: keys_test.go:87:     checking C-x...
--- PASS: TestKeymapStrToKeyValue (0.00s)
=== RUN   TestKeymapStrToKeyValueWithAlt
    TestKeymapStrToKeyValueWithAlt: keys_test.go:112: Checking Alt prefixed key name mapping...
    TestKeymapStrToKeyValueWithAlt: keys_test.go:114:     checking M-v...
    TestKeymapStrToKeyValueWithAlt: keys_test.go:114:     checking M-C-v...
    TestKeymapStrToKeyValueWithAlt: keys_test.go:114:     checking M-Space...
    TestKeymapStrToKeyValueWithAlt: keys_test.go:114:     checking M-MouseLeft...
--- PASS: TestKeymapStrToKeyValueWithAlt (0.00s)
=== RUN   TestKeymapStrToKeyValueCh
    TestKeymapStrToKeyValueCh: keys_test.go:137: Checking character mapping...
    TestKeymapStrToKeyValueCh: keys_test.go:139:     checking q...
    TestKeymapStrToKeyValueCh: keys_test.go:139:     checking w...
    TestKeymapStrToKeyValueCh: keys_test.go:139:     checking e...
    TestKeymapStrToKeyValueCh: keys_test.go:139:     checking r...
    TestKeymapStrToKeyValueCh: keys_test.go:139:     checking t...
    TestKeymapStrToKeyValueCh: keys_test.go:139:     checking y...
    TestKeymapStrToKeyValueCh: keys_test.go:139:     checking 🙏...
    TestKeymapStrToKeyValueCh: keys_test.go:139:     checking せ...
    TestKeymapStrToKeyValueCh: keys_test.go:139:     checking か...
    TestKeymapStrToKeyValueCh: keys_test.go:139:     checking い...
    TestKeymapStrToKeyValueCh: keys_test.go:139:     checking 〠...
--- PASS: TestKeymapStrToKeyValueCh (0.00s)
=== RUN   TestBalance
--- PASS: TestBalance (0.00s)
=== RUN   TestTrie
--- PASS: TestTrie (0.00s)
=== RUN   TestNotFound
--- PASS: TestNotFound (0.00s)
PASS
ok  	github.com/peco/peco/internal/keyseq	(cached)
?   	github.com/peco/peco/internal/util	[no test files]
?   	github.com/peco/peco/line	[no test files]
=== RUN   TestPipeline
START LineFeeder.Start
END LineFeeder.Start
END RegexpFilter.Accept
END RegexpFilter.Accept
END Receiver.Accept
    TestPipeline: pipeline_test.go:136: []string{"foobar"}
--- PASS: TestPipeline (0.00s)
PASS
ok  	github.com/peco/peco/pipeline	(cached)
?   	github.com/peco/peco/sig	[no test files]
```
</details>

### Preview
```
{
  "Prompt": "❯",
  "Style": {
    "Basic": [
      "on_default",
      "default"
    ],
    "SavedSelection": [
      "bold",
      "on_100",
      "120"
    ],
    "Selected": [
      "underline",
      "on_240",
      "214"
    ],
    "Query": [
      "177",
      "bold"
    ],
    "Matched": [
      "120"
    ]
  },
  "Use256Color": true
}
```
<img width="1439" alt="true" src="https://user-images.githubusercontent.com/28133383/83937403-2cea2000-a807-11ea-99dc-2f2aa6f2a38f.png">