### PR TITLE
Fix TOC in README.md

### DIFF
--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'README.md'
 
 jobs:
   generateTOC:
@@ -11,7 +13,9 @@ jobs:
 
     steps:
       - name: TOC Generator
-        uses: technote-space/toc-generator@v2
+        uses: neuenmuller/toc-generator@3d54e40125014baed3ba75617c44af2a42b9f67d
         with:
           TARGET_PATHS: README.md
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TOC_TITLE: ''
+          ENTIRE: true

--- a/README.md
+++ b/README.md
@@ -723,5 +723,7 @@ Implement all(?) of the original percol options
 Obviously, kudos to the original percol: https://github.com/mooz/percol
 Much code stolen from https://github.com/mattn/gof
 
+# Table of Contents
+
 <!-- START doctoc -->
 <!-- END doctoc -->


### PR DESCRIPTION
This PR includes:
- use patched [neuenmuller/toc-generator](https://github.com/neuenmuller/toc-generator)
  - this version supports `--entire` option which the patched [neuenmuller/doctoc](https://github.com/neuenmuller/doctoc) has.
  - version of toc-generator is specified by commit SHA (https://github.com/neuenmuller/toc-generator/commit/3d54e40125014baed3ba75617c44af2a42b9f67d) for security reason.
- added `Table of Contents` section to `README.md`

Fixes #507 