### PR TITLE
Use SSH deploy for TOC update

### DIFF
--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -12,10 +12,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: TOC Generator
-        uses: neuenmuller/toc-generator@3d54e40125014baed3ba75617c44af2a42b9f67d
+      - uses: actions/checkout@v2
         with:
-          TARGET_PATHS: README.md
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TOC_TITLE: ''
-          ENTIRE: true
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+      - run: sudo npm i --global neuenmuller/doctoc#entire
+      - run: doctoc --entire --notitle README.md
+      - name: setup git user
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+      - run: |
+          git add .
+          git commit -m "docs: update toc" || true
+          git push


### PR DESCRIPTION
TOC generator for README.md has fixed in PR #508 and it works well (generated TOC can be found in: https://github.com/peco/peco/commit/e272d60fdba4dfbbda85b226d5b1b1a3489c0958),
but it seems there still an issue failing to commit to `master` branch.

The cause is that our `master` branch has a `branch protection` enabled and `secrets.GITHUB_TOKEN` provided by
actions is not allowed to push to protected branch.

To solve this, we have several ways:
### Use Personal Access Token instead of `secrets.GITHUB_TOKEN`
This is the easiest to do, but it's hard to keep the project secure (Using someone's personal token is
a disaster. We need to create a new account, add them as a collaborator, then get token.) so I think
it's not the way.

### Use Deploy Key
This needs a workflow file to be completely changed, but more secure. Deploy key can be attached to one
repository and we do not need an additional user account.

This PR includes:
* Stop using `toc-generator` and use `doctoc` directly
* Push changes to `master` branch with the good old shell scripting using the deploy key

This PR requires **repository admin** to do some operations **before merging**:
* [ ] Generate ssh key-pair
* [ ] Register pubkey from Settings -> Deploy keys
* [ ] Register privkey as Secrets named `DEPLOY_KEY` from Settings -> Secrets

For more information, see https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys