### PR TITLE
switch back doctoc to official release

### DIFF
--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
-      - run: sudo npm i --global neuenmuller/doctoc#entire
-      - run: doctoc --entire --notitle README.md
+      - run: sudo npm i --global doctoc
+      - run: doctoc --all --notitle README.md
       - name: setup git user
         run: |
           git config --global user.name "${{ github.actor }}"


### PR DESCRIPTION
[doctoc v2.0.0](https://github.com/thlorenz/doctoc/releases/tag/v2.0.0) with `--all` flag (formerly `--entire`) is released!

This PR switches back `doctoc`, which is used in `.github/workflows/toc.yml` to generate TOC in `README.md`,
from the forked version (neuenmuller/doctoc) to the official release.
