### PR TITLE
docs: update reference to Arch Linux package

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,12 @@ scarf install peco
 xbps-install -S peco
 ```
 
-### Arch Linux (AUR)
+### Arch Linux
+
+There is an official Arch Linux package that can be installed via `pacman`:
 
 ```
-yay -S peco
+pacman -Syu peco
 ```
 
 ### Windows (Chocolatey NuGet Users)


### PR DESCRIPTION
Update the documentation in regards to installation on Arch Linux.

`peco` is now in the community repository. :)