### PR TITLE
Add installation instructions for the conda-format package

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,23 @@ There's a third-party [peco package available](https://chocolatey.org/packages/p
 C:\> choco install peco
 ```
 
+###  Linux / macOS / Windows (Conda, Mamba, Pixi)
+
+`conda`, `mamba` and `pixi` are platform-agnostic package managers for conda-format packages.
+
+This means that the same command can be used to install peco across Windows, MacOS, and Linux.
+
+```
+# conda
+conda install -c conda-forge peco
+
+# mamba
+mamba install -c conda-forge peco
+
+# install user-globally using pixi
+pixi global install peco
+```
+
 ### Building peco yourself
 
 Make sure to clone the source code under $GOPATH (i.e. $GOPATH/src/github.com/peco/peco). This is required


### PR DESCRIPTION
This pull request updates the `README.md` file to include installation instructions for `peco` using platform-agnostic package managers (`conda`, `mamba`, and `pixi`), making it easier for users to install `peco` across different operating systems.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R142-R158): Added a new section for installation instructions using `conda`, `mamba`, and `pixi`, highlighting their cross-platform compatibility for Windows, macOS, and Linux.