### PR TITLE
make mouse reporting opt-in via config

### DIFF
--- a/.claude/docs/cli.md
+++ b/.claude/docs/cli.md
@@ -29,6 +29,7 @@
 | `--print-query` | bool | Print query as first output line |
 | `--color` | ColorMode | Color mode: auto, none |
 | `--height` | string | Terminal height spec |
+| `--mouse` | bool | Enable mouse reporting (off by default; OR'd with `Mouse` config) |
 
 ## Exit Codes
 

--- a/Changes
+++ b/Changes
@@ -6,8 +6,9 @@ v0.6.1 - UNRELEASED
   * Mouse reporting is now disabled by default. Enabling it (as v0.6.0
     did unconditionally) prevents the terminal's own text selection,
     e.g. select-and-copy in iTerm2 is blocked. To bind mouse buttons
-    (`MouseLeft`/`MouseMiddle`/`MouseRight`) to actions, set
-    `"Mouse": true` in your config file (#823).
+    (`MouseLeft`/`MouseMiddle`/`MouseRight`) to actions, enable it with
+    the `--mouse` command line option or `"Mouse": true` in your config
+    file (#823).
 
 v0.6.0 - 24 Feb 2026
   [Breaking Changes]

--- a/Changes
+++ b/Changes
@@ -1,6 +1,14 @@
 Changes
 =======
 
+v0.6.1 - UNRELEASED
+  [Bugs/Fixes]
+  * Mouse reporting is now disabled by default. Enabling it (as v0.6.0
+    did unconditionally) prevents the terminal's own text selection,
+    e.g. select-and-copy in iTerm2 is blocked. To bind mouse buttons
+    (`MouseLeft`/`MouseMiddle`/`MouseRight`) to actions, set
+    `"Mouse": true` in your config file (#823).
+
 v0.6.0 - 24 Feb 2026
   [Breaking Changes]
   * Migrated terminal backend from termbox-go to tcell (#567).

--- a/README.md
+++ b/README.md
@@ -437,6 +437,12 @@ Without `--height`, peco uses the full terminal screen (default behavior, unchan
 
 **Note:** In inline mode, peco sets the environment variable `TCELL_ALTSCREEN=disable` to prevent tcell from using the alternate screen buffer, and restores the original value on exit. If peco is killed abnormally (e.g. `SIGKILL`), you may need to unset this variable manually: `unset TCELL_ALTSCREEN`.
 
+### --mouse
+
+Enables terminal mouse reporting so you can bind mouse buttons (`MouseLeft`, `MouseMiddle`, `MouseRight`) to actions in your `Keymap`.
+
+Mouse reporting is disabled by default because it prevents the terminal's own text selection (for example, select-and-copy in iTerm2 is blocked while mouse reporting is on). This flag is equivalent to setting `"Mouse": true` in the config file; the two are OR'd together, so either one enables it.
+
 # Configuration File
 
 peco by default consults a few locations for the config files.
@@ -524,6 +530,9 @@ It is disabled by default because enabling mouse reporting prevents the
 terminal's own text selection (for example, select-and-copy in iTerm2 is
 blocked while mouse reporting is on). Only turn this on if you actually bind
 mouse buttons to peco actions.
+
+This is equivalent to the `--mouse` command line option; the two are OR'd
+together, so either one enables mouse reporting.
 
 Default value for Mouse is false.
 

--- a/README.md
+++ b/README.md
@@ -509,6 +509,24 @@ When set to true, messages like "Running query..." will not be displayed.
 
 Default value for SuppressStatusMsg is false.
 
+### Mouse
+
+```json
+{
+    "Mouse": true
+}
+```
+
+Mouse enables terminal mouse reporting, which lets you bind mouse buttons
+(`MouseLeft`, `MouseMiddle`, `MouseRight`) to actions in the `Keymap` section.
+
+It is disabled by default because enabling mouse reporting prevents the
+terminal's own text selection (for example, select-and-copy in iTerm2 is
+blocked while mouse reporting is on). Only turn this on if you actually bind
+mouse buttons to peco actions.
+
+Default value for Mouse is false.
+
 ### OnCancel
 
 ```json

--- a/config/config.go
+++ b/config/config.go
@@ -96,6 +96,11 @@ type Config struct {
 	// Height specifies the display height in lines or percentage (e.g. "10", "50%").
 	// When set, peco renders inline without using the alternate screen buffer.
 	Height string `json:"Height" yaml:"Height"`
+
+	// Mouse enables terminal mouse reporting. It is disabled by default
+	// because enabling it prevents the terminal's native text selection
+	// (e.g. select-and-copy in iTerm2). Set to true to opt in.
+	Mouse bool `json:"Mouse" yaml:"Mouse"`
 }
 
 // SingleKeyJumpConfig holds configuration for single key jump mode.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -335,6 +335,45 @@ func TestColorMode(t *testing.T) {
 	})
 }
 
+func TestMouse(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		var cfg Config
+		require.NoError(t, cfg.Init())
+		require.False(t, cfg.Mouse, "mouse reporting must be off by default")
+	})
+
+	t.Run("opt-in via JSON", func(t *testing.T) {
+		for _, tc := range []struct {
+			input    string
+			expected bool
+		}{
+			{`{"Mouse":true}`, true},
+			{`{"Mouse":false}`, false},
+			{`{}`, false}, // absent key stays off
+		} {
+			var cfg Config
+			require.NoError(t, cfg.Init())
+			require.NoError(t, json.Unmarshal([]byte(tc.input), &cfg))
+			require.Equal(t, tc.expected, cfg.Mouse)
+		}
+	})
+
+	t.Run("opt-in via YAML", func(t *testing.T) {
+		for _, tc := range []struct {
+			input    string
+			expected bool
+		}{
+			{"Mouse: true", true},
+			{"Mouse: false", false},
+		} {
+			var cfg Config
+			require.NoError(t, cfg.Init())
+			require.NoError(t, yaml.Unmarshal([]byte(tc.input), &cfg))
+			require.Equal(t, tc.expected, cfg.Mouse)
+		}
+	})
+}
+
 func TestReadFilenameYAML(t *testing.T) {
 	dir := t.TempDir()
 	yamlFile := filepath.Join(dir, "config.yaml")

--- a/contrib/man/peco.1
+++ b/contrib/man/peco.1
@@ -741,6 +741,18 @@ behavior, unchanged).
 alternate screen buffer, and restores the original value on exit.
 If peco is killed abnormally (e.g.\ \f[V]SIGKILL\f[R]), you may need to
 unset this variable manually: \f[V]unset TCELL_ALTSCREEN\f[R].
+.SS \[en]mouse
+.PP
+Enables terminal mouse reporting so you can bind mouse buttons
+(\f[V]MouseLeft\f[R], \f[V]MouseMiddle\f[R], \f[V]MouseRight\f[R]) to
+actions in your \f[V]Keymap\f[R].
+.PP
+Mouse reporting is disabled by default because it prevents the
+terminal\[cq]s own text selection (for example, select-and-copy in
+iTerm2 is blocked while mouse reporting is on).
+This flag is equivalent to setting \f[V]\[dq]Mouse\[dq]: true\f[R] in
+the config file; the two are OR\[cq]d together, so either one enables
+it.
 .SH Configuration File
 .PP
 peco by default consults a few locations for the config files.
@@ -849,6 +861,9 @@ It is disabled by default because enabling mouse reporting prevents the
 terminal\[cq]s own text selection (for example, select-and-copy in
 iTerm2 is blocked while mouse reporting is on).
 Only turn this on if you actually bind mouse buttons to peco actions.
+.PP
+This is equivalent to the \f[V]--mouse\f[R] command line option; the two
+are OR\[cq]d together, so either one enables mouse reporting.
 .PP
 Default value for Mouse is false.
 .SS OnCancel

--- a/contrib/man/peco.1
+++ b/contrib/man/peco.1
@@ -831,6 +831,26 @@ When set to true, messages like \[lq]Running query\&...\[rq] will not be
 displayed.
 .PP
 Default value for SuppressStatusMsg is false.
+.SS Mouse
+.IP
+.nf
+\f[C]
+{
+    \[dq]Mouse\[dq]: true
+}
+\f[R]
+.fi
+.PP
+Mouse enables terminal mouse reporting, which lets you bind mouse
+buttons (\f[V]MouseLeft\f[R], \f[V]MouseMiddle\f[R],
+\f[V]MouseRight\f[R]) to actions in the \f[V]Keymap\f[R] section.
+.PP
+It is disabled by default because enabling mouse reporting prevents the
+terminal\[cq]s own text selection (for example, select-and-copy in
+iTerm2 is blocked while mouse reporting is on).
+Only turn this on if you actually bind mouse buttons to peco actions.
+.PP
+Default value for Mouse is false.
 .SS OnCancel
 .IP
 .nf

--- a/options.go
+++ b/options.go
@@ -33,6 +33,7 @@ type CLIOptions struct {
 	OptPrintQuery      bool             `long:"print-query" description:"print out the current query as first line of output"`
 	OptColor           config.ColorMode `long:"color" description:"color mode: 'auto' (default, parse ANSI codes) or 'none' (disable)" default:"auto"`
 	OptHeight          string           `long:"height" description:"display height in lines or percentage (e.g. '10', '50%')"`
+	OptMouse           bool             `long:"mouse" description:"enable mouse reporting. disabled by default because it\nblocks the terminal's own text selection (e.g. copy in iTerm2)"`
 }
 
 // parse parses command-line arguments and validates the resulting options.

--- a/peco.go
+++ b/peco.go
@@ -817,6 +817,11 @@ func (p *Peco) ApplyConfig(opts CLIOptions) error {
 		p.heightSpec = &spec
 	}
 
+	// Mouse: --mouse forces it on; otherwise the config value applies.
+	if opts.OptMouse {
+		p.config.Mouse = true
+	}
+
 	p.populateFilters()
 
 	if err := p.populateKeymap(); err != nil {

--- a/peco_test.go
+++ b/peco_test.go
@@ -469,6 +469,35 @@ func TestApplyConfig(t *testing.T) {
 		require.False(t, p.heightSpec.IsPercent, "p.heightSpec.IsPercent should be false for absolute CLI value")
 	})
 
+	t.Run("Mouse off by default", func(t *testing.T) {
+		p := newPeco()
+
+		var opts CLIOptions
+		require.NoError(t, p.ApplyConfig(opts), "p.ApplyConfig should succeed")
+
+		require.False(t, p.config.Mouse, "mouse should be off when neither --mouse nor config is set")
+	})
+
+	t.Run("--mouse enables mouse", func(t *testing.T) {
+		p := newPeco()
+
+		var opts CLIOptions
+		opts.OptMouse = true
+		require.NoError(t, p.ApplyConfig(opts), "p.ApplyConfig should succeed")
+
+		require.True(t, p.config.Mouse, "p.config.Mouse should be true when --mouse is set")
+	})
+
+	t.Run("config Mouse honored when --mouse absent", func(t *testing.T) {
+		p := newPeco()
+		p.config.Mouse = true
+
+		var opts CLIOptions
+		require.NoError(t, p.ApplyConfig(opts), "p.ApplyConfig should succeed")
+
+		require.True(t, p.config.Mouse, "config Mouse:true should be preserved when --mouse is absent")
+	})
+
 	t.Run("Config OnCancel used when CLI option absent", func(t *testing.T) {
 		p := newPeco()
 		p.config.OnCancel = config.OnCancelError

--- a/screen.go
+++ b/screen.go
@@ -258,7 +258,7 @@ func attributeToTcellStyle(fg, bg config.Attribute) tcell.Style {
 	return style
 }
 
-func (t *TcellScreen) Init(_ *config.Config) error {
+func (t *TcellScreen) Init(cfg *config.Config) error {
 	screen, err := tcell.NewScreen()
 	if err != nil {
 		return fmt.Errorf("failed to create tcell screen: %w", err)
@@ -268,7 +268,9 @@ func (t *TcellScreen) Init(_ *config.Config) error {
 		return fmt.Errorf("failed to initialize tcell screen: %w", err)
 	}
 
-	screen.EnableMouse()
+	if cfg != nil && cfg.Mouse {
+		screen.EnableMouse()
+	}
 
 	t.screen = screen
 	return nil

--- a/screen_inline.go
+++ b/screen_inline.go
@@ -39,7 +39,7 @@ func NewInlineScreen(spec config.HeightSpec) *InlineScreen {
 }
 
 // Init initializes the tcell screen for inline mode, disabling the alternate screen buffer.
-func (s *InlineScreen) Init(_ *config.Config) error {
+func (s *InlineScreen) Init(cfg *config.Config) error {
 	// Save and override TCELL_ALTSCREEN to prevent alternate screen buffer
 	s.savedAltscreen = os.Getenv("TCELL_ALTSCREEN")
 	os.Setenv("TCELL_ALTSCREEN", "disable")
@@ -55,7 +55,9 @@ func (s *InlineScreen) Init(_ *config.Config) error {
 		return fmt.Errorf("failed to initialize tcell screen: %w", err)
 	}
 
-	screen.EnableMouse()
+	if cfg != nil && cfg.Mouse {
+		screen.EnableMouse()
+	}
 
 	s.mutex.Lock()
 	s.screen = screen


### PR DESCRIPTION
- Mouse reporting is now off by default; v0.6.0 enabled it unconditionally, which blocks terminal text selection (e.g. select-and-copy in iTerm2)
- Enable it with the `--mouse` CLI flag or `"Mouse": true` in the config file (OR'd together)
- Lets you bind `MouseLeft`/`MouseMiddle`/`MouseRight` to actions in `Keymap`
- Fixes #823
